### PR TITLE
Wrap gridview into a grid controller

### DIFF
--- a/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
+++ b/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		805946D21E816D0E00EF7A2B /* AudioClipPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805946D11E816D0E00EF7A2B /* AudioClipPlayer.swift */; };
 		B49473BC446DC26204B223F1 /* Pods_MIDIchloriansUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD9072948CB8AB76A19799BB /* Pods_MIDIchloriansUITests.framework */; };
 		E9158EAB1E860CDB00B7ADF9 /* GridController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9158EAA1E860CDB00B7ADF9 /* GridController.swift */; };
+		E9158EB01E86353600B7ADF9 /* GridCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9158EAF1E86353600B7ADF9 /* GridCollectionViewController.swift */; };
+		E9158EB21E8645F800B7ADF9 /* PadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9158EB11E8645F800B7ADF9 /* PadView.swift */; };
 		E92F6C2C1E74F9FC00F5A092 /* SessionTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F6C2B1E74F9FC00F5A092 /* SessionTableViewController.swift */; };
 		E92F6C2E1E74FA3400F5A092 /* SessionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F6C2D1E74FA3400F5A092 /* SessionTableViewCell.swift */; };
 		E92F6C301E74FEBB00F5A092 /* SessionTableDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F6C2F1E74FEBB00F5A092 /* SessionTableDelegate.swift */; };
@@ -162,6 +164,8 @@
 		CD9072948CB8AB76A19799BB /* Pods_MIDIchloriansUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MIDIchloriansUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E6848E6E722EA2AD451EA962 /* Pods-MIDIchloriansUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MIDIchloriansUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MIDIchloriansUITests/Pods-MIDIchloriansUITests.release.xcconfig"; sourceTree = "<group>"; };
 		E9158EAA1E860CDB00B7ADF9 /* GridController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridController.swift; sourceTree = "<group>"; };
+		E9158EAF1E86353600B7ADF9 /* GridCollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridCollectionViewController.swift; sourceTree = "<group>"; };
+		E9158EB11E8645F800B7ADF9 /* PadView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PadView.swift; sourceTree = "<group>"; };
 		E92F6C2B1E74F9FC00F5A092 /* SessionTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionTableViewController.swift; sourceTree = "<group>"; };
 		E92F6C2D1E74FA3400F5A092 /* SessionTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionTableViewCell.swift; sourceTree = "<group>"; };
 		E92F6C2F1E74FEBB00F5A092 /* SessionTableDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionTableDelegate.swift; sourceTree = "<group>"; };
@@ -360,9 +364,11 @@
 		E9158EAE1E86155E00B7ADF9 /* Grid */ = {
 			isa = PBXGroup;
 			children = (
-				33EC0A3B1E6FD8C900229A92 /* GridCollectionView.swift */,
 				E9158EAA1E860CDB00B7ADF9 /* GridController.swift */,
+				E9158EAF1E86353600B7ADF9 /* GridCollectionViewController.swift */,
+				33EC0A3B1E6FD8C900229A92 /* GridCollectionView.swift */,
 				33EC0A3D1E6FD98800229A92 /* GridCollectionViewCell.swift */,
+				E9158EB11E8645F800B7ADF9 /* PadView.swift */,
 			);
 			name = Grid;
 			sourceTree = "<group>";
@@ -739,6 +745,7 @@
 				334970C11E72583F009C78DF /* Config.swift in Sources */,
 				F3173AA61E8306C30095F76A /* Animation.swift in Sources */,
 				E9EC7C4B1E83A81900769A8F /* TopBarController.swift in Sources */,
+				E9158EB21E8645F800B7ADF9 /* PadView.swift in Sources */,
 				E93A02C61E73F5FA00DFB2B7 /* AnimationTableViewCell.swift in Sources */,
 				E9158EAB1E860CDB00B7ADF9 /* GridController.swift in Sources */,
 				334970BF1E72557D009C78DF /* AnimationTypes.swift in Sources */,
@@ -759,6 +766,7 @@
 				334970C91E72B86B009C78DF /* LowLatencyAudio.swift in Sources */,
 				E99E8A491E800BA8001F9351 /* TopNavigationBar.swift in Sources */,
 				33120E1E1E6FD30A007E7717 /* AppDelegate.swift in Sources */,
+				E9158EB01E86353600B7ADF9 /* GridCollectionViewController.swift in Sources */,
 				E93A02C21E73C27200DFB2B7 /* SidePaneTabBarController.swift in Sources */,
 				E97733FC1E83CC3D00703A65 /* ModeDelegate.swift in Sources */,
 				F3173AA81E8306D20095F76A /* Audio.swift in Sources */,

--- a/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
+++ b/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		33EC0A441E6FE67700229A92 /* AnimationSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EC0A431E6FE67700229A92 /* AnimationSequence.swift */; };
 		805946D21E816D0E00EF7A2B /* AudioClipPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805946D11E816D0E00EF7A2B /* AudioClipPlayer.swift */; };
 		B49473BC446DC26204B223F1 /* Pods_MIDIchloriansUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD9072948CB8AB76A19799BB /* Pods_MIDIchloriansUITests.framework */; };
+		E9158EAB1E860CDB00B7ADF9 /* GridController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9158EAA1E860CDB00B7ADF9 /* GridController.swift */; };
 		E92F6C2C1E74F9FC00F5A092 /* SessionTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F6C2B1E74F9FC00F5A092 /* SessionTableViewController.swift */; };
 		E92F6C2E1E74FA3400F5A092 /* SessionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F6C2D1E74FA3400F5A092 /* SessionTableViewCell.swift */; };
 		E92F6C301E74FEBB00F5A092 /* SessionTableDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F6C2F1E74FEBB00F5A092 /* SessionTableDelegate.swift */; };
@@ -81,7 +82,6 @@
 		F3173ABD1E83B2B50095F76A /* AnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3173ABC1E83B2B50095F76A /* AnimationTests.swift */; };
 		F3173ABF1E83B2D50095F76A /* AudioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3173ABE1E83B2D50095F76A /* AudioTests.swift */; };
 		F3173AC11E83B2EF0095F76A /* DataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3173AC01E83B2EF0095F76A /* DataManagerTests.swift */; };
-		E9EC7C4B1E83A81900769A8F /* TopBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EC7C4A1E83A81900769A8F /* TopBarController.swift */; };
 		F34B2A521E7A84AC00FD2C61 /* Pad.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34B2A511E7A84AC00FD2C61 /* Pad.swift */; };
 		F36B995E1E8148260026721A /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36B995D1E8148260026721A /* DataManager.swift */; };
 		F3710A8F1E7D280D0031A754 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3710A8E1E7D280C0031A754 /* Session.swift */; };
@@ -161,6 +161,7 @@
 		A930F8946AA2BB25FBE6E119 /* Pods-MIDIchlorians.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MIDIchlorians.release.xcconfig"; path = "Pods/Target Support Files/Pods-MIDIchlorians/Pods-MIDIchlorians.release.xcconfig"; sourceTree = "<group>"; };
 		CD9072948CB8AB76A19799BB /* Pods_MIDIchloriansUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MIDIchloriansUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E6848E6E722EA2AD451EA962 /* Pods-MIDIchloriansUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MIDIchloriansUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MIDIchloriansUITests/Pods-MIDIchloriansUITests.release.xcconfig"; sourceTree = "<group>"; };
+		E9158EAA1E860CDB00B7ADF9 /* GridController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridController.swift; sourceTree = "<group>"; };
 		E92F6C2B1E74F9FC00F5A092 /* SessionTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionTableViewController.swift; sourceTree = "<group>"; };
 		E92F6C2D1E74FA3400F5A092 /* SessionTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionTableViewCell.swift; sourceTree = "<group>"; };
 		E92F6C2F1E74FEBB00F5A092 /* SessionTableDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionTableDelegate.swift; sourceTree = "<group>"; };
@@ -188,7 +189,6 @@
 		F3173ABC1E83B2B50095F76A /* AnimationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationTests.swift; sourceTree = "<group>"; };
 		F3173ABE1E83B2D50095F76A /* AudioTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioTests.swift; sourceTree = "<group>"; };
 		F3173AC01E83B2EF0095F76A /* DataManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataManagerTests.swift; sourceTree = "<group>"; };
-		E9EC7C4A1E83A81900769A8F /* TopBarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBarController.swift; sourceTree = "<group>"; };
 		F34B2A511E7A84AC00FD2C61 /* Pad.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pad.swift; sourceTree = "<group>"; };
 		F36B995D1E8148260026721A /* DataManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		F3710A8E1E7D280C0031A754 /* Session.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
@@ -253,14 +253,13 @@
 				33120E1D1E6FD30A007E7717 /* AppDelegate.swift */,
 				33120E1F1E6FD30A007E7717 /* ViewController.swift */,
 				E99E8A4A1E8016BF001F9351 /* Top Nav */,
-				E92F6C331E7522F700F5A092 /* Session */,
+				E92F6C331E7522F700F5A092 /* Session Table */,
 				E93A02CB1E7403B900DFB2B7 /* Side Pane */,
+				E9158EAE1E86155E00B7ADF9 /* Grid */,
 				33120E211E6FD30A007E7717 /* Main.storyboard */,
 				33120E241E6FD30A007E7717 /* Assets.xcassets */,
 				33120E261E6FD30A007E7717 /* LaunchScreen.storyboard */,
 				33120E291E6FD30A007E7717 /* Info.plist */,
-				33EC0A3B1E6FD8C900229A92 /* GridCollectionView.swift */,
-				33EC0A3D1E6FD98800229A92 /* GridCollectionViewCell.swift */,
 				33DAAAC31E72C38100987E86 /* Animation */,
 				334970C01E72583F009C78DF /* Config.swift */,
 				E93A02B11E738C0400DFB2B7 /* CGSize+Extensions.swift */,
@@ -358,14 +357,24 @@
 			path = ..;
 			sourceTree = "<group>";
 		};
-		E92F6C331E7522F700F5A092 /* Session */ = {
+		E9158EAE1E86155E00B7ADF9 /* Grid */ = {
+			isa = PBXGroup;
+			children = (
+				33EC0A3B1E6FD8C900229A92 /* GridCollectionView.swift */,
+				E9158EAA1E860CDB00B7ADF9 /* GridController.swift */,
+				33EC0A3D1E6FD98800229A92 /* GridCollectionViewCell.swift */,
+			);
+			name = Grid;
+			sourceTree = "<group>";
+		};
+		E92F6C331E7522F700F5A092 /* Session Table */ = {
 			isa = PBXGroup;
 			children = (
 				E92F6C2B1E74F9FC00F5A092 /* SessionTableViewController.swift */,
 				E92F6C2D1E74FA3400F5A092 /* SessionTableViewCell.swift */,
 				E92F6C2F1E74FEBB00F5A092 /* SessionTableDelegate.swift */,
 			);
-			name = Session;
+			name = "Session Table";
 			sourceTree = "<group>";
 		};
 		E92F6C341E7522FD00F5A092 /* Sample */ = {
@@ -731,6 +740,7 @@
 				F3173AA61E8306C30095F76A /* Animation.swift in Sources */,
 				E9EC7C4B1E83A81900769A8F /* TopBarController.swift in Sources */,
 				E93A02C61E73F5FA00DFB2B7 /* AnimationTableViewCell.swift in Sources */,
+				E9158EAB1E860CDB00B7ADF9 /* GridController.swift in Sources */,
 				334970BF1E72557D009C78DF /* AnimationTypes.swift in Sources */,
 				E93A02C81E73FA1D00DFB2B7 /* SideNavigationViewController.swift in Sources */,
 				E93A02C41E73F5E700DFB2B7 /* AnimationTableViewController.swift in Sources */,

--- a/MIDIchlorians/MIDIchlorians/Base.lproj/Main.storyboard
+++ b/MIDIchlorians/MIDIchlorians/Base.lproj/Main.storyboard
@@ -20,34 +20,8 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="egJ-YA-Z1d" customClass="GridCollectionView" customModule="MIDIchlorians" customModuleProvider="target">
-                                <rect key="frame" x="27" y="102" width="805" height="646"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" red="0.20000000300000001" green="0.20000000300000001" blue="0.20000000300000001" alpha="1" colorSpace="calibratedRGB"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="sHm-dG-T84">
-                                    <size key="itemSize" width="189" height="140"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="cell" id="YOr-6C-snJ" customClass="GridCollectionViewCell" customModule="MIDIchlorians" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="189" height="140"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                                            <rect key="frame" x="0.0" y="0.0" width="189" height="140"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </view>
-                                    </collectionViewCell>
-                                </cells>
-                            </collectionView>
-                        </subviews>
                         <color key="backgroundColor" red="0.20000000300000001" green="0.20000000300000001" blue="0.20000000300000001" alpha="1" colorSpace="calibratedRGB"/>
                     </view>
-                    <connections>
-                        <outlet property="gridCollection" destination="egJ-YA-Z1d" id="z66-oi-DhJ"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/MIDIchlorians/MIDIchlorians/Config.swift
+++ b/MIDIchlorians/MIDIchlorians/Config.swift
@@ -49,8 +49,17 @@ struct Config {
 
     static let TableViewSeparatorColor = UIColor(red: 66/255, green: 66/255, blue: 66/255, alpha: 1)
 
-    static let PadAreaResizeFactorWhenEditStart: CGFloat = 0.8
+    static let PadAreaResizeFactorWhenEditStart: CGFloat = 0.67
     static let PadAreaResizeFactorWhenEditEnd: CGFloat  = 1 / PadAreaResizeFactorWhenEditStart
+
+//    static let MainViewWidthToGridWidthRatio: CGFloat = 2 / 3
+    static let MainViewHeightToGridMinYRatio: CGFloat = 1 / 8
+    static let MainViewHeightToGridHeightRatio: CGFloat = 7 / 8
+
+    static let MainViewWidthToSideMinXRatio: CGFloat = 2 / 3
+    static let MainViewHeightToSideMinYRatio: CGFloat = 1 / 8
+    static let MainViewWidthToSideWidthRatio: CGFloat = 1 / 3
+    static let MainViewHeightToSideHeightRatio: CGFloat = 7 / 8
 
     static let SectionInsets = UIEdgeInsets(top: 0, left: 0, bottom: 10, right: 0)
     static let ItemInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)

--- a/MIDIchlorians/MIDIchlorians/Config.swift
+++ b/MIDIchlorians/MIDIchlorians/Config.swift
@@ -88,4 +88,5 @@ struct Config {
     static let TopNavSessionTitle = "Sessions"
     static let ModeSegmentTitles = ["PLAY", "EDIT"]
 
+    static let GridCollectionViewCellIdentifier = "cell"
 }

--- a/MIDIchlorians/MIDIchlorians/GridCollectionView.swift
+++ b/MIDIchlorians/MIDIchlorians/GridCollectionView.swift
@@ -16,6 +16,7 @@ class GridCollectionView: UICollectionView {
             }
         }
     }
+    weak var padDelegate: PadDelegate?
 
     private let audioManager = AudioManager()
     internal var selectedPad: IndexPath?
@@ -46,6 +47,8 @@ class GridCollectionView: UICollectionView {
         guard let indexPath = self.indexPathForItem(at: location) else {
             return
         }
+
+        padDelegate?.padTapped(indexPath: indexPath)
 
         // if in editing mode, highlight the tapped grid
         switch mode {
@@ -90,22 +93,6 @@ class GridCollectionView: UICollectionView {
                 return
         }
         AnimationEngine.register(animationSequence: animationSequence)
-        // end
-
-        // need session to return a pad from an indexPath
     }
 
-    func startListenAudio() {
-//        let ncdefault = NotificationCenter.default
-//        ncdefault.addObserver(forName: Notification.Name(rawValue:"Sound"), object: nil, queue: nil) { notification in
-            //handle notification
-//            guard let completedID = notification.userInfo?["completed"] as? UInt32 else {
-//                return
-//            }
-//            let cellPath = self.audioManager.getIndexPath(of: completedID)
-//            guard let _ = self.cellForItem(at: cellPath) else {
-//                return
-//            }
-//        }
-    }
 }

--- a/MIDIchlorians/MIDIchlorians/GridCollectionView.swift
+++ b/MIDIchlorians/MIDIchlorians/GridCollectionView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class GridCollectionView: UICollectionView, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+class GridCollectionView: UICollectionView {
     var mode: Mode = .Playing {
         didSet {
             if mode == .Playing, let selectedPad = selectedPad {
@@ -16,62 +16,9 @@ class GridCollectionView: UICollectionView, UICollectionViewDataSource, UICollec
             }
         }
     }
-    internal var currentSession: Session?
-    internal var currentPage = 0
 
-    private let reuseIdentifier = "cell"
     private let audioManager = AudioManager()
     internal var selectedPad: IndexPath?
-
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return Config.numberOfColumns
-    }
-
-    func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return Config.numberOfRows
-    }
-
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath)
-        -> UICollectionViewCell {
-            guard let cell = collectionView.dequeueReusableCell(
-                withReuseIdentifier: reuseIdentifier,
-                for: indexPath as IndexPath) as? GridCollectionViewCell else {
-                    return GridCollectionViewCell()
-            }
-            cell.rowNumber = indexPath.section
-            cell.columnNumber = indexPath.item
-            cell.setAppearance()
-            return cell
-    }
-
-    func collectionView(_ collectionView: UICollectionView,
-                        layout collectionViewLayout: UICollectionViewLayout,
-                        sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let totalLength = self.frame.width
-        let itemsPerRow = CGFloat(collectionView.numberOfItems(inSection: indexPath.section))
-        let insetLength = Config.ItemInsets.left * (itemsPerRow + 1)
-        let availableLength = totalLength - insetLength
-        let itemLength = availableLength / itemsPerRow
-        return CGSize(width: itemLength, height: itemLength)
-    }
-
-    func collectionView(_ collectionView: UICollectionView,
-                        layout collectionViewLayout: UICollectionViewLayout,
-                        minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
-        return Config.ItemInsets.left
-    }
-
-    func collectionView(_ collectionView: UICollectionView,
-                        layout collectionViewLayout: UICollectionViewLayout,
-                        minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return Config.ItemInsets.top
-    }
-
-    func collectionView(_ collectionView: UICollectionView,
-                        layout collectionViewLayout: UICollectionViewLayout,
-                        insetForSectionAt section: Int) -> UIEdgeInsets {
-        return Config.SectionInsets
-    }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         for touch in touches {
@@ -160,30 +107,5 @@ class GridCollectionView: UICollectionView, UICollectionViewDataSource, UICollec
 //                return
 //            }
 //        }
-    }
-}
-
-extension GridCollectionView: SampleTableDelegate {
-    func sampleTable(_: UITableView, didSelect sample: String) {
-        guard let row = self.selectedPad?.section, let col = self.selectedPad?.row else {
-            return
-        }
-        self.currentSession?.addAudio(page: self.currentPage, row: row, col: col, audioFile: sample)
-    }
-}
-
-extension GridCollectionView: AnimationTableDelegate {
-    func animationTable(_: UITableView, didSelect animation: String) {
-        guard let indexPath = self.selectedPad else {
-            return
-        }
-
-        guard let animationSequence = AnimationTypes.getAnimationSequenceForAnimationType(
-            animationTypeName: animation, indexPath: indexPath) else {
-                return
-        }
-
-        self.currentSession?.addAnimation(
-            page: self.currentPage, row: indexPath.section, col: indexPath.row, animation: animationSequence)
     }
 }

--- a/MIDIchlorians/MIDIchlorians/GridCollectionViewCell.swift
+++ b/MIDIchlorians/MIDIchlorians/GridCollectionViewCell.swift
@@ -8,13 +8,18 @@
 
 import UIKit
 
-class GridCollectionViewCell: UICollectionViewCell {
-
+class GridCollectionViewCell: UICollectionViewCell, PadView {
     var rowNumber = 0
     var columnNumber = 0
 
     func setAppearance() {
         self.backgroundColor = UIColor.darkGray
         self.contentView.subviews.forEach { $0.removeFromSuperview() }
+    }
+
+    func assign(sample: String) {
+    }
+
+    func assign(animation: AnimationSequence) {
     }
 }

--- a/MIDIchlorians/MIDIchlorians/GridCollectionViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/GridCollectionViewController.swift
@@ -1,0 +1,90 @@
+//
+//  GridCollectionViewController.swift
+//  MIDIchlorians
+//
+//  Created by Zhi An Ng on 25/3/17.
+//  Copyright © 2017 nus.cs3217.a0118897. All rights reserved.
+//
+
+import UIKit
+
+// Provides the data source and layout information for the underying GridCollectionView
+// Events that happen on the collection view will be sent to the parent GridController, not this view controller.
+class GridCollectionViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
+    // the currently visible 6x8 grid of pads
+    var padGrid: [[Pad]] = []
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+    // MARK: UICollectionViewDataSource
+
+    override func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return Config.numberOfRows
+    }
+
+    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return Config.numberOfColumns
+    }
+
+    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath)
+        -> UICollectionViewCell {
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: Config.GridCollectionViewCellIdentifier,
+                for: indexPath as IndexPath) as? GridCollectionViewCell else {
+                    return GridCollectionViewCell()
+            }
+
+            let pad = padGrid[indexPath.section][indexPath.row]
+            if let sample = pad.getAudioFile() {
+                cell.assign(sample: sample)
+            }
+            if let animation = pad.getAnimation() {
+                cell.assign(animation: animation)
+            }
+
+            cell.rowNumber = indexPath.section
+            cell.columnNumber = indexPath.item
+            cell.setAppearance()
+            return cell
+    }
+
+    // MARK: UICollectionViewDelegate
+
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let totalLength = collectionView.frame.width
+        // need to + 1 cos of the page buttons, this will be changed soon
+        let itemsPerRow = CGFloat(collectionView.numberOfItems(inSection: indexPath.section)) + 1
+        let insetLength = Config.ItemInsets.left * (itemsPerRow + 1)
+        let availableLength = totalLength - insetLength
+        let itemLength = availableLength / itemsPerRow
+        return CGSize(width: itemLength, height: itemLength)
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return Config.ItemInsets.left
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return Config.ItemInsets.top
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        insetForSectionAt section: Int) -> UIEdgeInsets {
+        return Config.SectionInsets
+    }
+
+}

--- a/MIDIchlorians/MIDIchlorians/GridController.swift
+++ b/MIDIchlorians/MIDIchlorians/GridController.swift
@@ -1,0 +1,144 @@
+//
+//  GridController.swift
+//  MIDIchlorians
+//
+//  Created by Zhi An Ng on 25/3/17.
+//  Copyright © 2017 nus.cs3217.a0118897. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class GridController: NSObject, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    // will make this internal soon
+    var view: UICollectionView {
+        return gridCollectionView
+    }
+    var gridCollectionView: GridCollectionView
+    internal var currentSession: Session?
+    internal var currentPage = 0
+    private let reuseIdentifier = "cell"
+    internal var selectedPad: IndexPath?
+    var mode: Mode = .Playing
+
+    init(gridCollectionView: GridCollectionView) {
+        self.gridCollectionView = gridCollectionView
+        self.gridCollectionView.backgroundColor = Config.BackgroundColor
+        self.currentSession = Session(bpm: Config.defaultBPM)
+
+        super.init()
+
+        self.gridCollectionView.dataSource = self
+        self.gridCollectionView.delegate = self
+        self.gridCollectionView.startListenAudio()
+    }
+
+    func setGridDimensions(superWidth: CGFloat) {
+        // fix the width of the button collection view
+        let totalWidth = superWidth - Config.AppLeftPadding - Config.AppRightPadding
+        // left with 9 columns of buttons with 8 insets in between
+        // so to get width for the pads we add 1 inset and times 8/9
+        let padWidth = (totalWidth + Config.ItemInsets.right) *
+            (CGFloat(Config.numberOfColumns) / CGFloat(Config.numberOfColumns + 1))
+        let padHeight = padWidth / CGFloat(Config.numberOfColumns) * CGFloat(Config.numberOfRows)
+        self.gridCollectionView.frame = CGRect(
+            origin: self.gridCollectionView.frame.origin,
+            size: CGSize(width: padWidth, height: padHeight))
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return Config.numberOfColumns
+    }
+
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return Config.numberOfRows
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath)
+        -> UICollectionViewCell {
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: reuseIdentifier,
+                for: indexPath as IndexPath) as? GridCollectionViewCell else {
+                    return GridCollectionViewCell()
+            }
+            cell.rowNumber = indexPath.section
+            cell.columnNumber = indexPath.item
+            cell.setAppearance()
+            return cell
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let totalLength = self.gridCollectionView.frame.width
+        let itemsPerRow = CGFloat(collectionView.numberOfItems(inSection: indexPath.section))
+        let insetLength = Config.ItemInsets.left * (itemsPerRow + 1)
+        let availableLength = totalLength - insetLength
+        let itemLength = availableLength / itemsPerRow
+        return CGSize(width: itemLength, height: itemLength)
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return Config.ItemInsets.left
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return Config.ItemInsets.top
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        insetForSectionAt section: Int) -> UIEdgeInsets {
+        return Config.SectionInsets
+    }
+}
+
+extension GridController: SampleTableDelegate {
+    func sampleTable(_: UITableView, didSelect sample: String) {
+        guard let row = self.selectedPad?.section, let col = self.selectedPad?.row else {
+            return
+        }
+        self.currentSession?.addAudio(page: self.currentPage, row: row, col: col, audioFile: sample)
+    }
+}
+
+extension GridController: AnimationTableDelegate {
+    func animationTable(_: UITableView, didSelect animation: String) {
+        guard let indexPath = self.selectedPad else {
+            return
+        }
+
+        guard let animationSequence = AnimationTypes.getAnimationSequenceForAnimationType(
+            animationTypeName: animation, indexPath: indexPath) else {
+                return
+        }
+
+        self.currentSession?.addAnimation(
+            page: self.currentPage, row: indexPath.section, col: indexPath.row, animation: animationSequence)
+    }
+}
+
+extension GridController: ModeSwitchDelegate {
+    func enterEdit() {
+        resizePads(by: Config.PadAreaResizeFactorWhenEditStart)
+        self.mode = .Editing
+    }
+
+    func enterPlay() {
+        resizePads(by: Config.PadAreaResizeFactorWhenEditEnd)
+        self.mode = .Playing
+    }
+
+    private func resizePads(by factor: CGFloat) {
+        // and to animate the changes refer to
+        // http://stackoverflow.com/questions/13780153/uicollectionview-animate-cell-size-change-on-selection
+        self.gridCollectionView.frame = CGRect(
+            origin: self.gridCollectionView.frame.origin,
+            size: self.gridCollectionView.frame.size.scale(by: factor))
+        self.gridCollectionView.collectionViewLayout.invalidateLayout()
+    }
+}

--- a/MIDIchlorians/MIDIchlorians/PadView.swift
+++ b/MIDIchlorians/MIDIchlorians/PadView.swift
@@ -1,0 +1,14 @@
+//
+//  PadView.swift
+//  MIDIchlorians
+//
+//  Created by Zhi An Ng on 25/3/17.
+//  Copyright © 2017 nus.cs3217.a0118897. All rights reserved.
+//
+
+import Foundation
+
+protocol PadView: class {
+    func assign(sample: String)
+    func assign(animation: AnimationSequence)
+}

--- a/MIDIchlorians/MIDIchlorians/Session.swift
+++ b/MIDIchlorians/MIDIchlorians/Session.swift
@@ -56,6 +56,10 @@ class Session: Object {
         return self.pads[page][indexPath.section][indexPath.row]
     }
 
+    func getGrid(page: Int) -> [[Pad]] {
+        return self.pads[page]
+    }
+
     //Should take audio struct
     func addAudio(page: Int, row: Int, col: Int, audioFile: String) {
         guard isValidPosition(page, row, col) else {

--- a/MIDIchlorians/MIDIchlorians/Session.swift
+++ b/MIDIchlorians/MIDIchlorians/Session.swift
@@ -52,6 +52,10 @@ class Session: Object {
         return sessionName
     }
 
+    func getPad(page: Int, indexPath: IndexPath) -> Pad {
+        return self.pads[page][indexPath.section][indexPath.row]
+    }
+
     //Should take audio struct
     func addAudio(page: Int, row: Int, col: Int, audioFile: String) {
         guard isValidPosition(page, row, col) else {

--- a/MIDIchlorians/MIDIchlorians/SidePaneController.swift
+++ b/MIDIchlorians/MIDIchlorians/SidePaneController.swift
@@ -50,8 +50,4 @@ class SidePaneController {
         sidePaneViewController.selectedIndex = 0
     }
 
-    func setDimension(frame: CGRect) {
-        self.view.frame = frame
-    }
-
 }

--- a/MIDIchlorians/MIDIchlorians/SidePaneController.swift
+++ b/MIDIchlorians/MIDIchlorians/SidePaneController.swift
@@ -50,4 +50,8 @@ class SidePaneController {
         sidePaneViewController.selectedIndex = 0
     }
 
+    func setDimension(frame: CGRect) {
+        self.view.frame = frame
+    }
+
 }

--- a/MIDIchlorians/MIDIchlorians/TopBarController.swift
+++ b/MIDIchlorians/MIDIchlorians/TopBarController.swift
@@ -14,7 +14,7 @@ class TopBarController {
         return topNavigationBar as UIView
     }
 
-    private var topNavigationBar = TopNavigationBar()
+    private var topNavigationBar: TopNavigationBar
     weak var modeSwitchDelegate: ModeSwitchDelegate? {
         didSet {
             topNavigationBar.modeSwitchDelegate = modeSwitchDelegate
@@ -26,10 +26,8 @@ class TopBarController {
         }
     }
 
-    func configureWidth(width: CGFloat) {
-        topNavigationBar = TopNavigationBar(
-            frame: CGRect(origin: CGPoint.zero,
-                          size: CGSize(width: width, height: Config.TopNavHeight)))
+    init(frame: CGRect) {
+        self.topNavigationBar = TopNavigationBar(frame: frame)
     }
 
 }

--- a/MIDIchlorians/MIDIchlorians/ViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/ViewController.swift
@@ -8,44 +8,14 @@
 
 import UIKit
 
-extension ViewController: ModeSwitchDelegate {
-    func enterEdit() {
-        let gridCollection = self.gridController.view
-        let fullHeight = gridCollection.frame.height
-
-        gridController.enterEdit()
-        // set the dimensions, replace with constraints soon
-
-        let minX = gridCollection.frame.maxX + Config.ItemInsets.right
-        let minY = gridCollection.frame.minY
-        let width = self.view.frame.width - gridCollection.frame.width
-            - Config.AppLeftPadding - Config.AppRightPadding
-        sidePaneController.setDimension(frame:
-            CGRect(x: minX, y: minY, width: width, height: fullHeight))
-        self.view.addSubview(sidePaneController.view)
-    }
-
-    func enterPlay() {
-        gridController.enterPlay()
-        sidePaneController.view.removeFromSuperview()
-    }
-}
-
-extension ViewController: SessionSelectorDelegate {
-    func sessionSelector(sender: UIBarButtonItem) {
-        self.present(sessionNavigationController, animated: false, completion: nil)
-
-        // configure styles and anchor of popover presentation controller
-        let popoverPresentationController = sessionNavigationController.popoverPresentationController
-        popoverPresentationController?.permittedArrowDirections = [.up]
-        popoverPresentationController?.barButtonItem = sender
-        popoverPresentationController?.backgroundColor = Config.BackgroundColor
-    }
-}
-
+// The ViewController is the main (and only) for the entire app.
+// Management and hooking up all child view controllers are done in this class.
+// The responsibilities of this class includes
+// - setting up dimensions (might be replaced by autoconstraint / snapkit)
+// - setting up delegates for side pane and grid
+// - initializing default styles for some views
 class ViewController: UIViewController {
-    @IBOutlet var gridCollection: GridCollectionView!
-    private var topBarController: TopBarController!
+    internal var topBarController: TopBarController!
     internal var sessionNavigationController: UINavigationController!
     internal var sidePaneController: SidePaneController!
     internal var gridController: GridController!
@@ -56,18 +26,11 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = Config.BackgroundColor
-
-        self.gridController = GridController(gridCollectionView: self.gridCollection)
-
-        self.gridController.setGridDimensions(superWidth: self.view.frame.width)
-
-        AnimationEngine.set(animationCollectionView: self.gridController.view)
-        AnimationEngine.start()
-
         setUpTopNav()
+        setUpGrid()
         setUpSidePane()
         setUpStyles()
+        setUpAnimation()
     }
 
     // Sets up the top navigation.
@@ -78,23 +41,81 @@ class ViewController: UIViewController {
         // present the session table as a popover
         sessionNavigationController.modalPresentationStyle = .popover
 
-        topBarController = TopBarController()
+        let navFrame = CGRect(origin: CGPoint.zero,
+                              size: CGSize(width: view.frame.width, height: Config.TopNavHeight))
+        topBarController = TopBarController(frame: navFrame)
 
-        topBarController.configureWidth(width: self.view.frame.width)
         topBarController.modeSwitchDelegate = self
         topBarController.sessionSelectorDelegate = self
 
-        self.view.addSubview(topBarController.view)
+        view.addSubview(topBarController.view)
     }
 
+    // Sets up the main grid for play/edit
+    private func setUpGrid() {
+        let frame = view.frame
+        let gridFrame = CGRect(x: frame.minX + Config.AppLeftPadding,
+                           y: frame.height * Config.MainViewHeightToGridMinYRatio,
+                           width: frame.width - Config.AppLeftPadding - Config.AppRightPadding,
+                           height: frame.height * Config.MainViewHeightToGridHeightRatio)
+        gridController = GridController(frame: gridFrame)
+
+        view.addSubview(gridController.view)
+    }
+
+    // Sets up the side pane with controls for samples and animations
     private func setUpSidePane() {
         sidePaneController = SidePaneController()
+        sidePaneController.sampleTableDelegate = gridController
+        sidePaneController.animationTableDelegate = gridController
+
+        let frame = view.frame
+        sidePaneController.view.frame =
+            CGRect(x: frame.width * Config.MainViewWidthToSideMinXRatio,
+                   y: frame.height * Config.MainViewHeightToSideMinYRatio,
+                   width: frame.width * Config.MainViewWidthToSideWidthRatio,
+                   height: frame.height * Config.MainViewHeightToSideHeightRatio)
     }
 
+    // Sets up application wide styles
     private func setUpStyles() {
+        view.backgroundColor = Config.BackgroundColor
+
         // proxy to make all table views have the same background color
         UITableView.appearance().backgroundColor = Config.BackgroundColor
         UITableViewCell.appearance().backgroundColor = Config.BackgroundColor
     }
 
+    // Sets up the animation engine
+    private func setUpAnimation() {
+        AnimationEngine.set(animationCollectionView: gridController.view)
+        AnimationEngine.start()
+    }
+
+}
+
+// Called when the mode is switch. Passes on the event to the grid and side pane
+extension ViewController: ModeSwitchDelegate {
+    func enterEdit() {
+        gridController.enterEdit()
+        view.addSubview(sidePaneController.view)
+    }
+
+    func enterPlay() {
+        gridController.enterPlay()
+        sidePaneController.view.removeFromSuperview()
+    }
+}
+
+// Called when session selector is tapped, shows the sessions as a popover
+extension ViewController: SessionSelectorDelegate {
+    func sessionSelector(sender: UIBarButtonItem) {
+        present(sessionNavigationController, animated: false, completion: nil)
+
+        // configure styles and anchor of popover presentation controller
+        let popoverPresentationController = sessionNavigationController.popoverPresentationController
+        popoverPresentationController?.permittedArrowDirections = [.up]
+        popoverPresentationController?.barButtonItem = sender
+        popoverPresentationController?.backgroundColor = Config.BackgroundColor
+    }
 }

--- a/MIDIchlorians/MIDIchlorians/ViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/ViewController.swift
@@ -19,6 +19,7 @@ class ViewController: UIViewController {
     internal var sessionNavigationController: UINavigationController!
     internal var sidePaneController: SidePaneController!
     internal var gridController: GridController!
+    internal var currentSession: Session!
 
     override var prefersStatusBarHidden: Bool {
         return true
@@ -58,7 +59,8 @@ class ViewController: UIViewController {
                            y: frame.height * Config.MainViewHeightToGridMinYRatio,
                            width: frame.width - Config.AppLeftPadding - Config.AppRightPadding,
                            height: frame.height * Config.MainViewHeightToGridHeightRatio)
-        gridController = GridController(frame: gridFrame)
+        currentSession = Session(bpm: Config.defaultBPM)
+        gridController = GridController(frame: gridFrame, session: currentSession)
 
         view.addSubview(gridController.view)
     }
@@ -88,7 +90,7 @@ class ViewController: UIViewController {
 
     // Sets up the animation engine
     private func setUpAnimation() {
-        AnimationEngine.set(animationCollectionView: gridController.view)
+        AnimationEngine.set(animationCollectionView: gridController.gridView)
         AnimationEngine.start()
     }
 
@@ -102,6 +104,7 @@ extension ViewController: ModeSwitchDelegate {
     }
 
     func enterPlay() {
+        // error handling
         gridController.enterPlay()
         sidePaneController.view.removeFromSuperview()
     }


### PR DESCRIPTION
First, sorry this is a big PR, a lot of it is copy and pasting what used to be in GridCollection to new classes.
I wrapped the GridCollectionView in a GridCollectionViewController, and that itself is managed by a GridController. GridCollectionViewController is the controller for only the view side, think of it as the VM in MVVM, and the GridCollectionView is necessary for us to override handling touches (otherwise we would have used a plain un-subclassed UICollectionView).
GridController deals with most of the business logic, like setting sample onto a pad. This can be cleaned up more, but for now I'm satisfied.

Also, defined some ratio based constants to define dimensions for the grid and side pane (previously it was relying on absolute amounts, like + 20 or - 20), this will help (i think) the transition into autolayout based view.