### PR TITLE
Move a bunch of grid view logic into controller

### DIFF
--- a/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
+++ b/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		E93A02CD1E7403CD00DFB2B7 /* AnimationTableDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93A02CC1E7403CD00DFB2B7 /* AnimationTableDelegate.swift */; };
 		E97733FC1E83CC3D00703A65 /* ModeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93A02B51E7390DD00DFB2B7 /* ModeDelegate.swift */; };
 		E99E8A491E800BA8001F9351 /* TopNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99E8A481E800BA8001F9351 /* TopNavigationBar.swift */; };
+		E9AD301B1E88EBB300801A9F /* PadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AD301A1E88EBB300801A9F /* PadDelegate.swift */; };
 		E9EC7C471E8395AC00769A8F /* SidePaneController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EC7C461E8395AC00769A8F /* SidePaneController.swift */; };
 		E9EC7C4B1E83A81900769A8F /* TopBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EC7C4A1E83A81900769A8F /* TopBarController.swift */; };
 		E9EC7C4D1E83B7F100769A8F /* SessionSelectorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EC7C4C1E83B7F100769A8F /* SessionSelectorDelegate.swift */; };
@@ -189,6 +190,7 @@
 		E93A02C91E74017000DFB2B7 /* SampleTableDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleTableDelegate.swift; sourceTree = "<group>"; };
 		E93A02CC1E7403CD00DFB2B7 /* AnimationTableDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationTableDelegate.swift; sourceTree = "<group>"; };
 		E99E8A481E800BA8001F9351 /* TopNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopNavigationBar.swift; sourceTree = "<group>"; };
+		E9AD301A1E88EBB300801A9F /* PadDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PadDelegate.swift; sourceTree = "<group>"; };
 		E9EC7C461E8395AC00769A8F /* SidePaneController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidePaneController.swift; sourceTree = "<group>"; };
 		E9EC7C4A1E83A81900769A8F /* TopBarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBarController.swift; sourceTree = "<group>"; };
 		E9EC7C4C1E83B7F100769A8F /* SessionSelectorDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionSelectorDelegate.swift; sourceTree = "<group>"; };
@@ -381,6 +383,7 @@
 			isa = PBXGroup;
 			children = (
 				E9158EAA1E860CDB00B7ADF9 /* GridController.swift */,
+				E9AD301A1E88EBB300801A9F /* PadDelegate.swift */,
 				E9158EAF1E86353600B7ADF9 /* GridCollectionViewController.swift */,
 				33EC0A3B1E6FD8C900229A92 /* GridCollectionView.swift */,
 				33EC0A3D1E6FD98800229A92 /* GridCollectionViewCell.swift */,
@@ -835,6 +838,7 @@
 				33120E1E1E6FD30A007E7717 /* AppDelegate.swift in Sources */,
 				E9158EB01E86353600B7ADF9 /* GridCollectionViewController.swift in Sources */,
 				E93A02C21E73C27200DFB2B7 /* SidePaneTabBarController.swift in Sources */,
+				E9AD301B1E88EBB300801A9F /* PadDelegate.swift in Sources */,
 				E97733FC1E83CC3D00703A65 /* ModeDelegate.swift in Sources */,
 				F3173AA81E8306D20095F76A /* Audio.swift in Sources */,
 				33EC0A401E6FE40500229A92 /* AnimationEngine.swift in Sources */,

--- a/MIDIchlorians/MIDIchlorians/GridCollectionView.swift
+++ b/MIDIchlorians/MIDIchlorians/GridCollectionView.swift
@@ -9,90 +9,21 @@
 import UIKit
 
 class GridCollectionView: UICollectionView {
-    var mode: Mode = .playing {
-        didSet {
-            if mode == .playing, let selectedPad = selectedPad {
-                unselectCell(at: selectedPad)
-            }
-        }
-    }
     weak var padDelegate: PadDelegate?
-
-    private let audioManager = AudioManager()
-    internal var selectedPad: IndexPath?
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         for touch in touches {
             let touchLocation = touch.location(in: self)
-            gridTapped(location: touchLocation)
+
+            guard let indexPath = self.indexPathForItem(at: touchLocation) else {
+                return
+            }
+
+            padDelegate?.padTapped(indexPath: indexPath)
         }
     }
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-    }
-
-    func selectCell(at indexPath: IndexPath) {
-        self.selectedPad = indexPath
-        let cell = self.cellForItem(at: indexPath)
-        cell?.layer.borderColor = UIColor.red.cgColor
-        cell?.layer.borderWidth = 3.0
-    }
-
-    func unselectCell(at indexPath: IndexPath) {
-        let cell = self.cellForItem(at: indexPath)
-        cell?.layer.borderWidth = 0.0
-    }
-
-    func gridTapped(location: CGPoint) {
-        guard let indexPath = self.indexPathForItem(at: location) else {
-            return
-        }
-
-        padDelegate?.padTapped(indexPath: indexPath)
-
-        // if in editing mode, highlight the tapped grid
-        switch mode {
-        case .editing:
-            // this is the second tap on a grid, first tap to select, second tap will play
-            if self.selectedPad == indexPath {
-                // play music
-            } else {
-                if let selectedPad = selectedPad {
-                    self.unselectCell(at: selectedPad)
-                }
-                self.selectCell(at: indexPath)
-                return
-            }
-        case .playing:
-            break
-        }
-
-        // hardcoded animations for demo
-        if (indexPath.section == 0 || indexPath.section == Config.numberOfRows - 1) &&
-            (indexPath.item == 0 || indexPath.item == Config.numberOfColumns - 1) {
-            guard let animationSequence = AnimationTypes.getAnimationSequenceForAnimationType(
-                animationTypeName: Config.animationTypeSpreadName,
-                indexPath: indexPath) else {
-                    return
-            }
-            AnimationEngine.register(animationSequence: animationSequence)
-            return
-        }
-        if indexPath.section > 1 && indexPath.item > 2 && indexPath.section < 4 && indexPath.item < 5 {
-            guard let animationSequence = AnimationTypes.getAnimationSequenceForAnimationType(
-                animationTypeName: Config.animationTypeSparkName,
-                indexPath: indexPath) else {
-                    return
-            }
-            AnimationEngine.register(animationSequence: animationSequence)
-            return
-        }
-        guard let animationSequence = AnimationTypes.getAnimationSequenceForAnimationType(
-            animationTypeName: Config.animationTypeRainbowName,
-            indexPath: indexPath) else {
-                return
-        }
-        AnimationEngine.register(animationSequence: animationSequence)
     }
 
 }

--- a/MIDIchlorians/MIDIchlorians/GridCollectionViewCell.swift
+++ b/MIDIchlorians/MIDIchlorians/GridCollectionViewCell.swift
@@ -39,4 +39,14 @@ extension GridCollectionViewCell: AnimatablePad {
 
     func assign(animation: AnimationSequence) {
     }
+
+    // This cell is selected in the edit mode
+    func setSelected() {
+        layer.borderColor = UIColor.red.cgColor
+        layer.borderWidth = 3.0
+    }
+
+    func unselect() {
+        layer.borderWidth = 0.0
+    }
 }

--- a/MIDIchlorians/MIDIchlorians/GridCollectionViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/GridCollectionViewController.swift
@@ -12,15 +12,24 @@ import UIKit
 // Events that happen on the collection view will be sent to the parent GridController, not this view controller.
 class GridCollectionViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
     // the currently visible 6x8 grid of pads
-    var padGrid: [[Pad]] = []
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    var padGrid: [[Pad]] = [] {
+        didSet {
+            collectionView?.reloadData()
+        }
     }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+    // currently selected pad, only used for edit mode
+    var selectedIndexPath: IndexPath? {
+        didSet {
+            // reload previously selected pad to clear selection
+            if let prevIndexPath = oldValue {
+                collectionView?.reloadItems(at: [prevIndexPath])
+            }
+            // reload new selected pad to show selection
+            if let newIndexPath = selectedIndexPath {
+                collectionView?.reloadItems(at: [newIndexPath])
+            }
+        }
     }
 
     // MARK: UICollectionViewDataSource
@@ -42,16 +51,25 @@ class GridCollectionViewController: UICollectionViewController, UICollectionView
             }
 
             let pad = padGrid[indexPath.section][indexPath.row]
+
             if let sample = pad.getAudioFile() {
                 cell.assign(sample: sample)
             }
+
             if let animation = pad.getAnimation() {
                 cell.assign(animation: animation)
+            }
+
+            if selectedIndexPath == indexPath {
+                cell.setSelected()
+            } else {
+                cell.unselect()
             }
 
             cell.rowNumber = indexPath.section
             cell.columnNumber = indexPath.item
             cell.setDefaultAppearance()
+
             return cell
     }
 

--- a/MIDIchlorians/MIDIchlorians/PadDelegate.swift
+++ b/MIDIchlorians/MIDIchlorians/PadDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  PadDelegate.swift
+//  MIDIchlorians
+//
+//  Created by Zhi An Ng on 27/3/17.
+//  Copyright © 2017 nus.cs3217.a0118897. All rights reserved.
+//
+
+import Foundation
+
+protocol PadDelegate: class {
+    func padTapped(indexPath: IndexPath)
+}


### PR DESCRIPTION
What happened here is that I tried to make `GridCollectionView` simpler, so all it does now is handle multitouch and calls the delegate, which is the `GridController`.
I moved some logic into the `GridCollectionViewController`, which will highlight the currently selected cell by configuring the view cell.

`GridController` seems to be growing quite a bit, because it has to manage the pad touch logic, as well as react when the side bar is tapped.