### PR TITLE
Enabling relative animations

### DIFF
--- a/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
+++ b/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
@@ -14,14 +14,16 @@
 		33120E251E6FD30A007E7717 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33120E241E6FD30A007E7717 /* Assets.xcassets */; };
 		33120E281E6FD30A007E7717 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 33120E261E6FD30A007E7717 /* LaunchScreen.storyboard */; };
 		33120E331E6FD30A007E7717 /* MIDIchloriansUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33120E321E6FD30A007E7717 /* MIDIchloriansUITests.swift */; };
-		334970BF1E72557D009C78DF /* AnimationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334970BE1E72557D009C78DF /* AnimationTypes.swift */; };
+		334970BF1E72557D009C78DF /* AnimationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334970BE1E72557D009C78DF /* AnimationType.swift */; };
 		334970C11E72583F009C78DF /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334970C01E72583F009C78DF /* Config.swift */; };
 		334970C31E726AE9009C78DF /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334970C21E726AE9009C78DF /* UIColorExtension.swift */; };
 		334970C71E72B83D009C78DF /* AudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334970C61E72B83D009C78DF /* AudioManager.swift */; };
 		334970C91E72B86B009C78DF /* LowLatencyAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334970C81E72B86B009C78DF /* LowLatencyAudio.swift */; };
+		334CE58C1E8A3ED00095E143 /* AnimationTypeCreationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334CE58B1E8A3ED00095E143 /* AnimationTypeCreationMode.swift */; };
 		33A2754D1E7BEF56000B1B15 /* Colour.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A2754C1E7BEF56000B1B15 /* Colour.swift */; };
 		33BCC5AA1E85064900D8489F /* AnimatableGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BCC5A91E85064900D8489F /* AnimatableGrid.swift */; };
 		33BCC5AC1E85067A00D8489F /* AnimatablePad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BCC5AB1E85067A00D8489F /* AnimatablePad.swift */; };
+		33CC26C71E891E840077F0ED /* AnimationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC26C61E891E840077F0ED /* AnimationManager.swift */; };
 		33DAAAA51E72BEA300987E86 /* AWOLNATION - Sail-1.wav in Resources */ = {isa = PBXBuildFile; fileRef = 33DAAA881E72BEA300987E86 /* AWOLNATION - Sail-1.wav */; };
 		33DAAAA61E72BEA300987E86 /* AWOLNATION - Sail-2.wav in Resources */ = {isa = PBXBuildFile; fileRef = 33DAAA891E72BEA300987E86 /* AWOLNATION - Sail-2.wav */; };
 		33DAAAA71E72BEA300987E86 /* AWOLNATION - Sail-3.wav in Resources */ = {isa = PBXBuildFile; fileRef = 33DAAA8A1E72BEA300987E86 /* AWOLNATION - Sail-3.wav */; };
@@ -123,14 +125,16 @@
 		33120E2E1E6FD30A007E7717 /* MIDIchloriansUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MIDIchloriansUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		33120E321E6FD30A007E7717 /* MIDIchloriansUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDIchloriansUITests.swift; sourceTree = "<group>"; };
 		33120E341E6FD30A007E7717 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		334970BE1E72557D009C78DF /* AnimationTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationTypes.swift; sourceTree = "<group>"; };
+		334970BE1E72557D009C78DF /* AnimationType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationType.swift; sourceTree = "<group>"; };
 		334970C01E72583F009C78DF /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		334970C21E726AE9009C78DF /* UIColorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		334970C61E72B83D009C78DF /* AudioManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AudioManager.swift; path = MIDIchlorians/AudioManager.swift; sourceTree = "<group>"; };
 		334970C81E72B86B009C78DF /* LowLatencyAudio.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LowLatencyAudio.swift; sourceTree = "<group>"; };
+		334CE58B1E8A3ED00095E143 /* AnimationTypeCreationMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationTypeCreationMode.swift; sourceTree = "<group>"; };
 		33A2754C1E7BEF56000B1B15 /* Colour.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Colour.swift; sourceTree = "<group>"; };
 		33BCC5A91E85064900D8489F /* AnimatableGrid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableGrid.swift; sourceTree = "<group>"; };
 		33BCC5AB1E85067A00D8489F /* AnimatablePad.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatablePad.swift; sourceTree = "<group>"; };
+		33CC26C61E891E840077F0ED /* AnimationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationManager.swift; sourceTree = "<group>"; };
 		33DAAA881E72BEA300987E86 /* AWOLNATION - Sail-1.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = "AWOLNATION - Sail-1.wav"; path = "MIDIchlorians/SailSample/AWOLNATION - Sail-1.wav"; sourceTree = "<group>"; };
 		33DAAA891E72BEA300987E86 /* AWOLNATION - Sail-2.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = "AWOLNATION - Sail-2.wav"; path = "MIDIchlorians/SailSample/AWOLNATION - Sail-2.wav"; sourceTree = "<group>"; };
 		33DAAA8A1E72BEA300987E86 /* AWOLNATION - Sail-3.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = "AWOLNATION - Sail-3.wav"; path = "MIDIchlorians/SailSample/AWOLNATION - Sail-3.wav"; sourceTree = "<group>"; };
@@ -335,11 +339,13 @@
 				33EC0A3F1E6FE40500229A92 /* AnimationEngine.swift */,
 				33EC0A411E6FE55000229A92 /* AnimationBit.swift */,
 				33EC0A431E6FE67700229A92 /* AnimationSequence.swift */,
-				334970BE1E72557D009C78DF /* AnimationTypes.swift */,
+				334970BE1E72557D009C78DF /* AnimationType.swift */,
 				334970C21E726AE9009C78DF /* UIColorExtension.swift */,
 				33A2754C1E7BEF56000B1B15 /* Colour.swift */,
 				33BCC5A91E85064900D8489F /* AnimatableGrid.swift */,
 				33BCC5AB1E85067A00D8489F /* AnimatablePad.swift */,
+				33CC26C61E891E840077F0ED /* AnimationManager.swift */,
+				334CE58B1E8A3ED00095E143 /* AnimationTypeCreationMode.swift */,
 			);
 			name = Animation;
 			sourceTree = "<group>";
@@ -814,7 +820,7 @@
 				E9158EB21E8645F800B7ADF9 /* PadView.swift in Sources */,
 				E93A02C61E73F5FA00DFB2B7 /* AnimationTableViewCell.swift in Sources */,
 				E9158EAB1E860CDB00B7ADF9 /* GridController.swift in Sources */,
-				334970BF1E72557D009C78DF /* AnimationTypes.swift in Sources */,
+				334970BF1E72557D009C78DF /* AnimationType.swift in Sources */,
 				E93A02C81E73FA1D00DFB2B7 /* SideNavigationViewController.swift in Sources */,
 				E93A02C41E73F5E700DFB2B7 /* AnimationTableViewController.swift in Sources */,
 				33BCC5AC1E85067A00D8489F /* AnimatablePad.swift in Sources */,
@@ -822,6 +828,7 @@
 				E93A02BC1E73B9CE00DFB2B7 /* SampleTableViewController.swift in Sources */,
 				33EC0A421E6FE55000229A92 /* AnimationBit.swift in Sources */,
 				334970C71E72B83D009C78DF /* AudioManager.swift in Sources */,
+				33CC26C71E891E840077F0ED /* AnimationManager.swift in Sources */,
 				F34B2A521E7A84AC00FD2C61 /* Pad.swift in Sources */,
 				33A2754D1E7BEF56000B1B15 /* Colour.swift in Sources */,
 				E92F6C2E1E74FA3400F5A092 /* SessionTableViewCell.swift in Sources */,
@@ -839,6 +846,7 @@
 				F3173AA81E8306D20095F76A /* Audio.swift in Sources */,
 				33EC0A401E6FE40500229A92 /* AnimationEngine.swift in Sources */,
 				334970C31E726AE9009C78DF /* UIColorExtension.swift in Sources */,
+				334CE58C1E8A3ED00095E143 /* AnimationTypeCreationMode.swift in Sources */,
 				E92F6C2C1E74F9FC00F5A092 /* SessionTableViewController.swift in Sources */,
 				E92F6C301E74FEBB00F5A092 /* SessionTableDelegate.swift in Sources */,
 				33BCC5AA1E85064900D8489F /* AnimatableGrid.swift in Sources */,

--- a/MIDIchlorians/MIDIchlorians/AnimationManager.swift
+++ b/MIDIchlorians/MIDIchlorians/AnimationManager.swift
@@ -1,25 +1,25 @@
 //
-//  AnimationTypes.swift
+//  AnimationManager.swift
 //  MIDIchlorians
 //
-//  Created by anands on 10/3/17.
+//  Created by anands on 27/3/17.
 //  Copyright © 2017 nus.cs3217.a0118897. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
-class AnimationTypes {
+class AnimationManager {
+    static var instance = AnimationManager()
 
-    private static var animationTypes = [String: AnimationSequence]()
+    private var animationTypes = [String: AnimationType]()
 
-    // returns the names of all the animation types including the predefined ones
-    static func getAllAnimationTypesNames() -> [String] {
+    func getAllAnimationTypesNames() -> [String] {
         var arrayOfNames = Array(animationTypes.keys)
         arrayOfNames.append(contentsOf: getPredefinedAnimationTypesNames())
         return arrayOfNames
     }
 
-    private static func getPredefinedAnimationTypesNames() -> [String] {
+    private func getPredefinedAnimationTypesNames() -> [String] {
         return [
             Config.animationTypeSparkName,
             Config.animationTypeSpreadName,
@@ -27,8 +27,8 @@ class AnimationTypes {
         ]
     }
 
-    static func getAnimationSequenceForAnimationType(animationTypeName: String,
-                                                     indexPath: IndexPath) -> AnimationSequence? {
+    func getAnimationSequenceForAnimationType(animationTypeName: String,
+                                              indexPath: IndexPath) -> AnimationSequence? {
         switch animationTypeName {
         case Config.animationTypeSpreadName:
             return spreadFromCenter()
@@ -37,15 +37,80 @@ class AnimationTypes {
         case Config.animationTypeRainbowName:
             return rainbow(indexPath: indexPath)
         default:
-            return animationTypes[animationTypeName]
+            guard let animationType = animationTypes[animationTypeName] else {
+                return nil
+            }
+            if animationType.mode == .relative {
+                return derelativiseAnimationSequence(
+                    animationSequence: animationType.animationSequence,
+                    clickedIndex: indexPath
+                )
+            }
+            return animationType.animationSequence
         }
     }
 
-    static func addNewAnimationType(name: String, animationSequence: AnimationSequence) {
-        animationTypes[name] = animationSequence
+    func addNewAnimationType(name: String, animationSequence: AnimationSequence,
+                             mode: AnimationTypeCreationMode, anchor: IndexPath) {
+        var animationType: AnimationType
+        if mode == .relative {
+            animationType = AnimationType(
+                name: name,
+                animationSequence: relativiseAnimationSequence(animationSequence: animationSequence, anchor: anchor),
+                mode: mode
+            )
+        } else {
+            animationType = AnimationType(
+                name: name,
+                animationSequence: animationSequence,
+                mode: mode
+            )
+        }
+        animationTypes[name] = animationType
     }
 
-    static func spark(indexPath: IndexPath) -> AnimationSequence {
+    private func relativiseAnimationSequence(animationSequence: AnimationSequence,
+                                             anchor: IndexPath) -> AnimationSequence {
+
+        return transformAnimationSequence(
+            animationSequence: animationSequence,
+            rowOffset: -anchor.section,
+            columnOffset: -anchor.item
+        )
+    }
+
+    private func derelativiseAnimationSequence(animationSequence: AnimationSequence,
+                                               clickedIndex: IndexPath) -> AnimationSequence {
+
+        return transformAnimationSequence(
+            animationSequence: animationSequence,
+            rowOffset: clickedIndex.section,
+            columnOffset: clickedIndex.item
+        )
+    }
+
+    private func transformAnimationSequence(animationSequence: AnimationSequence,
+                                            rowOffset: Int, columnOffset: Int) -> AnimationSequence {
+        let transformedAnimationSequence = AnimationSequence()
+        var tickCount = 0
+
+        while let animationBits = animationSequence.next() {
+            let transformedAnimationBits = animationBits.map({(animationBit: AnimationBit) -> AnimationBit in
+                return AnimationBit(
+                    colour: animationBit.colour,
+                    row: animationBit.row + rowOffset,
+                    column: animationBit.column + columnOffset
+                )
+            })
+            for animationBit in transformedAnimationBits {
+                transformedAnimationSequence.addAnimationBit(atTick: tickCount, animationBit: animationBit)
+            }
+            tickCount += 1
+        }
+        return transformedAnimationSequence
+    }
+
+    private func spark(indexPath: IndexPath) -> AnimationSequence {
         let animationSequence = AnimationSequence()
         animationSequence.addAnimationBit(
             atTick: 0,
@@ -81,7 +146,7 @@ class AnimationTypes {
         return animationSequence
     }
 
-    static func rainbow(indexPath: IndexPath) -> AnimationSequence {
+    private func rainbow(indexPath: IndexPath) -> AnimationSequence {
         let animationSequence = AnimationSequence()
         let arrayOfColours = Colour.allColours
         for count in 0..<arrayOfColours.count {
@@ -98,7 +163,7 @@ class AnimationTypes {
         return animationSequence
     }
 
-    static func spreadFromCenter() -> AnimationSequence {
+    private func spreadFromCenter() -> AnimationSequence {
         let animationSequence = AnimationSequence()
 
         addAnimationBitToSequenceFrom(arrayOfTuples: arrayOfInnerTuples, tick: 0,
@@ -138,8 +203,8 @@ class AnimationTypes {
         return animationSequence
     }
 
-    private static func addAnimationBitToSequenceFrom(arrayOfTuples: [(Int, Int)], tick: Int,
-                                                      colour: Colour, animationSequence: AnimationSequence) {
+    private func addAnimationBitToSequenceFrom(arrayOfTuples: [(Int, Int)], tick: Int,
+                                               colour: Colour, animationSequence: AnimationSequence) {
         for tuple in arrayOfTuples {
             animationSequence.addAnimationBit(
                 atTick: tick,
@@ -152,13 +217,13 @@ class AnimationTypes {
         }
     }
 
-    private static let arrayOfInnerTuples = [
+    private let arrayOfInnerTuples = [
         (2, 3),
         (3, 3),
         (2, 4),
         (3, 4)
     ]
-    private static let arrayOfMiddleTuples = [
+    private let arrayOfMiddleTuples = [
         (1, 2),
         (1, 3),
         (1, 4),
@@ -172,7 +237,7 @@ class AnimationTypes {
         (4, 4),
         (4, 5)
     ]
-    private static let arrayOfOuterTuples = [
+    private let arrayOfOuterTuples = [
         (0, 0),
         (0, 1),
         (0, 2),

--- a/MIDIchlorians/MIDIchlorians/AnimationType.swift
+++ b/MIDIchlorians/MIDIchlorians/AnimationType.swift
@@ -1,0 +1,56 @@
+//
+//  AnimationTypes.swift
+//  MIDIchlorians
+//
+//  Created by anands on 10/3/17.
+//  Copyright © 2017 nus.cs3217.a0118897. All rights reserved.
+//
+
+import UIKit
+
+class AnimationType {
+    var name: String
+    var mode: AnimationTypeCreationMode
+    var animationSequence: AnimationSequence
+
+    init(name: String, animationSequence: AnimationSequence, mode: AnimationTypeCreationMode) {
+        self.name = name
+        self.mode = mode
+        self.animationSequence = animationSequence
+    }
+
+    func getJSONforAnimationType() -> String? {
+        var dictionary = [String: Any]()
+        dictionary[Config.animationTypeNameKey] = name
+        dictionary[Config.animationTypeModeKey] = mode
+        dictionary[Config.animationTypeAnimationSequenceKey] = animationSequence.getJSONforAnimationSequence()
+
+        guard let jsonData = try? JSONSerialization.data(
+            withJSONObject: dictionary,
+            options: JSONSerialization.WritingOptions.prettyPrinted
+            ) else {
+                return nil
+        }
+        return String(data: jsonData, encoding: .utf8)
+    }
+
+    static func getAnimationTypeFromJSON(fromJSON: String) -> AnimationType? {
+        guard let data = fromJSON.data(using: .utf8) else {
+            return nil
+        }
+        guard let dictionary = (try? JSONSerialization.jsonObject(with: data, options: [])) as? [String: Any] else {
+            return nil
+        }
+        guard let name = dictionary[Config.animationTypeNameKey] as? String else {
+            return nil
+        }
+        guard let mode = dictionary[Config.animationTypeModeKey] as? AnimationTypeCreationMode else {
+            return nil
+        }
+        guard let animationSequence = dictionary[Config.animationTypeAnimationSequenceKey] as? AnimationSequence else {
+            return nil
+        }
+        let animationType = AnimationType(name: name, animationSequence: animationSequence, mode: mode)
+        return animationType
+    }
+}

--- a/MIDIchlorians/MIDIchlorians/AnimationTypeCreationMode.swift
+++ b/MIDIchlorians/MIDIchlorians/AnimationTypeCreationMode.swift
@@ -1,0 +1,14 @@
+//
+//  AnimationTypeCreationMode.swift
+//  MIDIchlorians
+//
+//  Created by anands on 28/3/17.
+//  Copyright © 2017 nus.cs3217.a0118897. All rights reserved.
+//
+
+import Foundation
+
+enum AnimationTypeCreationMode {
+    case relative
+    case absolute
+}

--- a/MIDIchlorians/MIDIchlorians/Config.swift
+++ b/MIDIchlorians/MIDIchlorians/Config.swift
@@ -80,6 +80,10 @@ struct Config {
     static let animationBitRowKey = "row"
     static let animationBitColumnKey = "column"
 
+    static let animationTypeModeKey = "mode"
+    static let animationTypeAnimationSequenceKey = "animationSequence"
+    static let animationTypeNameKey = "name"
+
     static let animationTypeSpreadName = "Spread"
     static let animationTypeSparkName = "Spark"
     static let animationTypeRainbowName = "Rainbow"

--- a/MIDIchlorians/MIDIchlorians/GridCollectionView.swift
+++ b/MIDIchlorians/MIDIchlorians/GridCollectionView.swift
@@ -70,7 +70,7 @@ class GridCollectionView: UICollectionView {
         // hardcoded animations for demo
         if (indexPath.section == 0 || indexPath.section == Config.numberOfRows - 1) &&
             (indexPath.item == 0 || indexPath.item == Config.numberOfColumns - 1) {
-            guard let animationSequence = AnimationTypes.getAnimationSequenceForAnimationType(
+            guard let animationSequence = AnimationManager.instance.getAnimationSequenceForAnimationType(
                 animationTypeName: Config.animationTypeSpreadName,
                 indexPath: indexPath) else {
                     return
@@ -79,7 +79,7 @@ class GridCollectionView: UICollectionView {
             return
         }
         if indexPath.section > 1 && indexPath.item > 2 && indexPath.section < 4 && indexPath.item < 5 {
-            guard let animationSequence = AnimationTypes.getAnimationSequenceForAnimationType(
+            guard let animationSequence = AnimationManager.instance.getAnimationSequenceForAnimationType(
                 animationTypeName: Config.animationTypeSparkName,
                 indexPath: indexPath) else {
                     return
@@ -87,7 +87,7 @@ class GridCollectionView: UICollectionView {
             AnimationEngine.register(animationSequence: animationSequence)
             return
         }
-        guard let animationSequence = AnimationTypes.getAnimationSequenceForAnimationType(
+        guard let animationSequence = AnimationManager.instance.getAnimationSequenceForAnimationType(
             animationTypeName: Config.animationTypeRainbowName,
             indexPath: indexPath) else {
                 return

--- a/MIDIchlorians/MIDIchlorians/GridController.swift
+++ b/MIDIchlorians/MIDIchlorians/GridController.swift
@@ -88,7 +88,7 @@ extension GridController: AnimationTableDelegate {
             return
         }
 
-        guard let animationSequence = AnimationTypes.getAnimationSequenceForAnimationType(
+        guard let animationSequence = AnimationManager.instance.getAnimationSequenceForAnimationType(
             animationTypeName: animation, indexPath: indexPath) else {
                 return
         }


### PR DESCRIPTION
@ngzhian `AnimationType` refers to the types of animations which will show up in the side bar. 

In this PR, I have
- Created a new enum `AnimationTypeCreationMode` with two values `.relative` and `.absolute`
- Created a new `AnimationManager` with a singleton instance which can be used to define new animation types
```
AnimationManager.instance.addNewAnimationType(name: String, animationSequence: AnimationSequence,
                             mode: AnimationTypeCreationMode, anchor: IndexPath)
```
- `AnimationSequence` for a given `AnimationType` and IndexPath of the clicked pad can be obtainted by calling
```
AnimationManager.instance.getAnimationSequenceForAnimationType(animationTypeName: String,
                                                     indexPath: IndexPath) -> AnimationSequence? 
```

@advaypal, you can serialize/deserialize `AnimationType` to JSON string by calling
- `animationType.getJSONforAnimationType() -> String?`
- `AnimationType.getAnimationTypeFromJSON(fromJSON: String) -> AnimationType?`
