### PR TITLE
Fix for saving sample name

### DIFF
--- a/MIDIchlorians/MIDIchlorians/AppDelegate.swift
+++ b/MIDIchlorians/MIDIchlorians/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // Copy samples from the bundle onto user's document directory.
     // A list of URLs of the copied samples.
-    func copyBundleSamples() -> [URL] {
+    func copyBundleSamples() -> [String] {
         // store the samples in the document directory
         guard let docsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last else {
             // if we cannot store, that's fine, the user just won't have any samples loaded
@@ -34,13 +34,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
 
-        func copyToUserStorage(_ sampleName: String) -> URL? {
+        func copyToUserStorage(_ sampleName: String) -> String? {
             let sampleURL = Bundle.main.url(forResource: sampleName, withExtension: Config.SoundExt)
             guard let srcURL = sampleURL else {
                 return nil
             }
             let destURL = docsURL.appendingPathComponent("\(sampleName).\(Config.SoundExt)")
-            return copy(src: srcURL, dest: destURL)
+            return copy(src: srcURL, dest: destURL) != nil ? sampleName : nil
         }
 
         return preloadedSamples.flatMap { copyToUserStorage($0) }
@@ -56,7 +56,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Populate the samples in our database
         copiedSamples.forEach { sample in
             // if saving fails, what are we gonna do?
-            let _ = DataManager.instance.saveAudio(sample.absoluteString)
+            let _ = DataManager.instance.saveAudio(sample)
         }
 
         // Do the same thing for animations as well

--- a/MIDIchlorians/MIDIchlorians/AudioManager.swift
+++ b/MIDIchlorians/MIDIchlorians/AudioManager.swift
@@ -30,10 +30,13 @@ struct AudioManager {
     //call this to play audio with single directory
     //returns success
     func play(audioDir: String, bpm: Int? = nil ) -> Bool {
-        guard let audioID = audioDict[audioDir] else {
+        let audioID = audioDict[audioDir] ?? AudioClipPlayer.initAudioClip(audioDir: audioDir)
+
+        guard let audio = audioID else {
             return false
         }
-        AudioClipPlayer.playAudioClip(soundID: audioID)
+
+        AudioClipPlayer.playAudioClip(soundID: audio)
         return true
     }
 

--- a/MIDIchlorians/MIDIchlorians/Session.swift
+++ b/MIDIchlorians/MIDIchlorians/Session.swift
@@ -36,20 +36,12 @@ class Session: Object {
     }
 
     private func initialisePadGrid() {
-        //for demo
-        let demoSounds = Config.sound
         for page in 0..<numPages {
             pads.append([])
             for row in 0..<numRows {
                 pads[page].append([])
-                for col in 0..<numCols {
+                for _ in 0..<numCols {
                     let emptyPad = Pad()
-                    //for demo
-                    if AudioManager.instance.hackCheckValidIndex(row: row, col: col) {
-                        let demoSound = demoSounds[row][col]
-                        _ = AudioManager.instance.initAudio(audioDir: demoSound)
-                        emptyPad.addAudio(audioFile: demoSound)
-                    }
                     pads[page][row].append(emptyPad)
                 }
 


### PR DESCRIPTION
My previous commit saved the full path of a sample in the Audio model, which caused interesting problems (FileManager's url for documents directory returned different results).
In the interest of time I have reverted such changes and reverted to loading using the file name (instead of a full path).
The refactoring work shall be done in the future (probably by someone else :P)