### PR TITLE
Fix bug caused due to deleted session

### DIFF
--- a/MIDIchlorians/MIDIchlorians/DataManager.swift
+++ b/MIDIchlorians/MIDIchlorians/DataManager.swift
@@ -62,7 +62,7 @@ class DataManager {
         }
     }
 
-    func saveSession(_ sessionName: String, _ session: Session) -> Bool {
+    func saveSession(_ sessionName: String, _ session: Session) -> Session? {
         var savedSession = session
         if sessionNames.contains(sessionName) {
             _ = removeSession(sessionName)
@@ -80,14 +80,14 @@ class DataManager {
             try realm?.write { realm?.add(savedSession) }
 
         } catch {
-            return false
+            return nil
         }
 
         if !sessionNames.contains(sessionName) {
             self.sessionNames.insert(sessionName)
         }
 
-        return true
+        return Session(session: session)
     }
 
     func removeSession(_ sessionName: String) -> Bool {

--- a/MIDIchlorians/MIDIchlorians/DataManager.swift
+++ b/MIDIchlorians/MIDIchlorians/DataManager.swift
@@ -64,10 +64,6 @@ class DataManager {
 
     func saveSession(_ sessionName: String, _ session: Session) -> Session? {
         var savedSession = session
-        if sessionNames.contains(sessionName) {
-            _ = removeSession(sessionName)
-        }
-
         if session.getSessionName() != nil {
             savedSession = Session(session: session)
             savedSession.prepareForSave(sessionName: sessionName)
@@ -76,8 +72,10 @@ class DataManager {
         }
 
         do {
-            try realm?.write { realm?.add(SessionName(sessionName)) }
-            try realm?.write { realm?.add(savedSession) }
+            if !sessionNames.contains(sessionName) {
+                try realm?.write { realm?.add(SessionName(sessionName)) }
+            }
+            try realm?.write { realm?.add(savedSession, update: true) }
 
         } catch {
             return nil

--- a/MIDIchlorians/MIDIchloriansTests/DataManagerTests.swift
+++ b/MIDIchlorians/MIDIchloriansTests/DataManagerTests.swift
@@ -25,16 +25,21 @@ class DataManagerTests: XCTestCase {
         let animationSequence = AnimationManager.instance.getAnimationSequenceForAnimationType(
             animationTypeName: Config.animationTypeSparkName, indexPath: IndexPath(row: 0, section: 0))
         session.addAnimation(page: 0, row: 0, col: 0, animation: animationSequence!)
-        XCTAssertTrue(dataManager.saveSession("test", session))
+        XCTAssertTrue(session.equals(dataManager.saveSession("test", session)!))
         XCTAssertTrue(session.equals(dataManager.loadSession("test")!))
     }
 
     func testSaveSessionOverrwrite() {
         let session = Session(bpm: 120)
-        XCTAssertTrue(dataManager.saveSession("test", session))
+        XCTAssertTrue(session.equals(dataManager.saveSession("test", session)!))
         let newSession = Session(bpm: 140)
-        XCTAssertTrue(dataManager.saveSession("test", newSession))
+        let newSession1 = dataManager.saveSession("test", newSession)!
+        XCTAssertTrue(newSession.equals(newSession1))
         XCTAssertTrue(newSession.equals(dataManager.loadSession("test")!))
+
+        newSession1.addAudio(page: 0, row: 0, col: 0, audioFile: "AWOLNATION - Sail-2")
+        XCTAssertTrue(newSession1.equals(dataManager.saveSession("test", newSession1)!))
+
     }
 
     func testRemoveSession() {


### PR DESCRIPTION
Fixes the bug that didn't allow a user to modify an old session. Changed API to return a new session in case the session is saved successfully and nil if the save fails. Performing all subsequent session modification operations on the returned session should fix the issue