### PR TITLE
Grid select side

### DIFF
--- a/MIDIchlorians/MIDIchlorians/Config.swift
+++ b/MIDIchlorians/MIDIchlorians/Config.swift
@@ -98,6 +98,9 @@ struct Config {
     static let TopNavSessionTitle = "Sessions"
     static let ModeSegmentTitles = ["PLAY", "EDIT"]
 
+    static let DefaultSessionName = "New Session"
+
+    static let SessionTableTitle = "Sessions"
     static let AnimationTabTitle = "Animations"
 
     static let GridCollectionViewCellIdentifier = "cell"

--- a/MIDIchlorians/MIDIchlorians/GridController.swift
+++ b/MIDIchlorians/MIDIchlorians/GridController.swift
@@ -25,7 +25,11 @@ class GridController: NSObject {
     }
     weak var padDelegate: PadDelegate?
 
-    internal var currentSession: Session
+    internal var currentSession: Session {
+        didSet {
+            gridCollectionVC.padGrid = currentSession.getGrid(page: currentPage)
+        }
+    }
     internal var currentPage = 0
     // Keep the selectedIndexPath of the view controller in sync
     internal var selectedIndexPath: IndexPath? {

--- a/MIDIchlorians/MIDIchlorians/SessionTableDelegate.swift
+++ b/MIDIchlorians/MIDIchlorians/SessionTableDelegate.swift
@@ -11,5 +11,10 @@ import UIKit
 
 // Adopt this protocol to react to selection of a session in SessionTableViewController
 protocol SessionTableDelegate: class {
-    func sessionTable(_: UITableView, didSelect session: String)
+    // A session in the table is selected, we probably want to load it
+    func sessionTable(_: UITableView, didSelect sessionName: String)
+    // The add button in the session table is selected
+    func sessionTable(_: UITableView)
+    // A session is deleted
+    func sessionTable(_: UITableView, didRemove sessionName: String)
 }

--- a/MIDIchlorians/MIDIchlorians/SessionTableViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/SessionTableViewController.swift
@@ -11,16 +11,25 @@ import UIKit
 class SessionTableViewController: UITableViewController {
     weak var delegate: SessionTableDelegate?
 
-    private let data = ["Session 1", "Session 2"]
+    var sessions: [String] = [] {
+        didSet {
+            tableView.reloadData()
+        }
+    }
     private let reuseIdentifier = Config.SessionTableReuseIdentifier
     private let newSessionButton = UIBarButtonItem(barButtonSystemItem: .add, target: nil, action: nil)
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.title = "Sessions"
+        self.title = Config.SessionTableTitle
         self.navigationItem.rightBarButtonItem = self.editButtonItem
         self.navigationItem.leftBarButtonItem = self.newSessionButton
+
+        // have to set target/action here for this to work, not above in the inistnatiation.
+        self.newSessionButton.target = self
+        self.newSessionButton.action = #selector(newSession(barButton:))
+
         self.tableView.register(SessionTableViewCell.self, forCellReuseIdentifier: reuseIdentifier)
         self.tableView.separatorColor = Config.TableViewSeparatorColor
     }
@@ -37,7 +46,7 @@ class SessionTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return data.count
+        return sessions.count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -46,15 +55,34 @@ class SessionTableViewController: UITableViewController {
                 return SessionTableViewCell()
         }
 
-        cell.textLabel?.text = data[indexPath.row]
+        cell.textLabel?.text = sessions[indexPath.row]
 
         return cell
     }
 
     override func tableView(_ tableView: UITableView,
+                            commit editingStyle: UITableViewCellEditingStyle,
+                            forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            let deletedSession = sessions.remove(at: indexPath.row)
+            delegate?.sessionTable(tableView, didRemove: deletedSession)
+        }
+    }
+
+    // MARK: - Table view delegate
+
+    override func tableView(_ tableView: UITableView,
                             willDisplay cell: UITableViewCell,
                             forRowAt indexPath: IndexPath) {
         cell.textLabel?.textColor = Config.SessionTableViewCellColor
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        delegate?.sessionTable(tableView, didSelect: sessions[indexPath.row])
+    }
+
+    func newSession(barButton: UIBarButtonItem) {
+        delegate?.sessionTable(tableView)
     }
 
 }

--- a/MIDIchlorians/MIDIchlorians/SidePaneController.swift
+++ b/MIDIchlorians/MIDIchlorians/SidePaneController.swift
@@ -55,8 +55,8 @@ class SidePaneController {
 
 extension SidePaneController: PadDelegate {
     // Get index of sample assigned to selected pad in sample list
-    private func index(of selected: Pad) -> Int? {
-        return selected
+    private func indexOfSample(assignedTo pad: Pad) -> Int? {
+        return pad
             .getAudioFile()
             .flatMap { sample in sampleTableViewController.sampleList.index(of: sample) }
     }
@@ -73,7 +73,7 @@ extension SidePaneController: PadDelegate {
     // that is the sample assigned to the pad
     // If the pad has no sample assigned, deselect everything.
     func pad(selected: Pad) {
-        guard let index = index(of: selected) else {
+        guard let index = indexOfSample(assignedTo: selected) else {
             deselect()
             return
         }

--- a/MIDIchlorians/MIDIchlorians/TopBarController.swift
+++ b/MIDIchlorians/MIDIchlorians/TopBarController.swift
@@ -30,4 +30,9 @@ class TopBarController {
         self.topNavigationBar = TopNavigationBar(frame: frame)
     }
 
+    func setTargetActionOfSaveButton(target: AnyObject, selector: Selector) {
+        topNavigationBar.saveButton.target = target
+        topNavigationBar.saveButton.action = selector
+    }
+
 }

--- a/MIDIchlorians/MIDIchlorians/TopNavigationBar.swift
+++ b/MIDIchlorians/MIDIchlorians/TopNavigationBar.swift
@@ -27,12 +27,14 @@ class TopNavigationBar: UINavigationBar {
             style: .plain,
             target: self,
             action: #selector(sessionSelect(sender:)))
+    // temporary button to trigger save of session
+    var saveButton = UIBarButtonItem(barButtonSystemItem: .save, target: nil, action: nil)
 
     override init(frame: CGRect) {
         super.init(frame: frame)
 
         // set up session selector on the left of navigation bar
-        baseNavigationItem.leftBarButtonItem = sessionSelector
+        baseNavigationItem.leftBarButtonItems = [sessionSelector, saveButton]
 
         // set up segmented control for mode selection
         modeSegmentedControl.selectedSegmentIndex = 0

--- a/MIDIchlorians/MIDIchlorians/ViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/ViewController.swift
@@ -138,3 +138,9 @@ extension ViewController: SessionSelectorDelegate {
         popoverPresentationController?.backgroundColor = Config.BackgroundColor
     }
 }
+
+extension ViewController: PadDelegate {
+    func pad(selected: Pad) {
+        sidePaneController.pad(selected: selected)
+    }
+}

--- a/MIDIchlorians/MIDIchlorians/ViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/ViewController.swift
@@ -138,9 +138,3 @@ extension ViewController: SessionSelectorDelegate {
         popoverPresentationController?.backgroundColor = Config.BackgroundColor
     }
 }
-
-extension ViewController: PadDelegate {
-    func pad(selected: Pad) {
-        sidePaneController.pad(selected: selected)
-    }
-}

--- a/MIDIchlorians/MIDIchlorians/ViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/ViewController.swift
@@ -171,3 +171,32 @@ extension ViewController: SessionSelectorDelegate {
         popoverPresentationController?.backgroundColor = Config.BackgroundColor
     }
 }
+
+extension ViewController: SessionTableDelegate {
+    func sessionTable(_: UITableView, didSelect sessionName: String) {
+        // try to load session
+        let loadedSession = dataManager.loadSession(sessionName)
+        if loadedSession == nil {
+            // failed to load this session, which is weird since we got the session name from the data manager
+            // maybe we can show some error error
+        } else {
+            // session successfully loaded
+            self.currentSession = loadedSession
+        }
+        sessionNavigationController.dismiss(animated: true, completion: nil)
+    }
+
+    func sessionTable(_: UITableView) {
+        // create a new blank session
+        currentSession = Session(bpm: Config.defaultBPM)
+        // save it
+        saveCurrentSession()
+        // then we reload the session lists in sessionTableViewController
+        sessionTableViewController.sessions = dataManager.loadAllSessionNames()
+        sessionNavigationController.dismiss(animated: true, completion: nil)
+    }
+
+    func sessionTable(_: UITableView, didRemove sessionName: String) {
+        _ = dataManager.removeSession(sessionName)
+    }
+}

--- a/MIDIchlorians/MIDIchlorians/ViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/ViewController.swift
@@ -17,10 +17,18 @@ import RealmSwift
 class ViewController: UIViewController {
     internal var topBarController: TopBarController!
     internal var sessionNavigationController: UINavigationController!
+    internal var sessionTableViewController: SessionTableViewController!
     internal var sidePaneController: SidePaneController!
     internal var animationDesignController: AnimationDesignerController!
     internal var gridController: GridController!
-    internal var currentSession: Session!
+    internal var currentSession: Session! {
+        didSet {
+            if currentSession != nil {
+            gridController?.currentSession = currentSession
+            }
+        }
+    }
+    internal var dataManager = DataManager()
 
     override var prefersStatusBarHidden: Bool {
         return true
@@ -42,10 +50,12 @@ class ViewController: UIViewController {
     // Sets up the top navigation.
     // The top navigation has controls to show the session table, so we set that up here as well.
     private func setUpTopNav() {
-        let sessionTableViewController = SessionTableViewController(style: .plain)
+        sessionTableViewController = SessionTableViewController(style: .plain)
+        sessionTableViewController.sessions = dataManager.loadAllSessionNames()
         sessionNavigationController = UINavigationController(rootViewController: sessionTableViewController)
         // present the session table as a popover
         sessionNavigationController.modalPresentationStyle = .popover
+        sessionTableViewController.delegate = self
 
         let navFrame = CGRect(origin: CGPoint.zero,
                               size: CGSize(width: view.frame.width, height: Config.TopNavHeight))
@@ -53,8 +63,31 @@ class ViewController: UIViewController {
 
         topBarController.modeSwitchDelegate = self
         topBarController.sessionSelectorDelegate = self
+        topBarController.setTargetActionOfSaveButton(target: self, selector: #selector(saveCurrentSession))
 
         view.addSubview(topBarController.view)
+    }
+
+    // Saves the current session
+    func saveCurrentSession() {
+        currentSession = dataManager.saveSession(Config.DefaultSessionName, currentSession)
+    }
+
+    // Tries to load a session, if no sessions exists then returns nil
+    private func loadFirstSessionIfExsists() -> Session? {
+        func loadTillSuccessOrEnd(names: [String]) -> Session? {
+            guard let name = names.first else {
+                return nil
+            }
+
+            if let session = dataManager.loadSession(name) {
+                return session
+            } else {
+                let tail = Array(names.suffix(0))
+                return loadTillSuccessOrEnd(names: tail)
+            }
+        }
+        return loadTillSuccessOrEnd(names: dataManager.loadAllSessionNames())
     }
 
     // Sets up the main grid for play/edit
@@ -64,7 +97,7 @@ class ViewController: UIViewController {
                            y: frame.height * Config.MainViewHeightToGridMinYRatio,
                            width: frame.width - Config.AppLeftPadding - Config.AppRightPadding,
                            height: frame.height * Config.MainViewHeightToGridHeightRatio)
-        currentSession = Session(bpm: Config.defaultBPM)
+        currentSession = loadFirstSessionIfExsists() ?? Session(bpm: Config.defaultBPM)
         gridController = GridController(frame: gridFrame, session: currentSession)
 
         view.addSubview(gridController.view)

--- a/MIDIchlorians/MIDIchlorians/ViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/ViewController.swift
@@ -24,7 +24,7 @@ class ViewController: UIViewController {
     internal var currentSession: Session! {
         didSet {
             if currentSession != nil {
-            gridController?.currentSession = currentSession
+                gridController?.currentSession = currentSession
             }
         }
     }


### PR DESCRIPTION
1. Load sessions when the app first starts, this is done by querying data manager for a list of session names and trying to load one successfully
2. allows creating new session from session table (currently a blank session with a default name will be created)
3. allows deleting session from the session table