### PR TITLE
Indicate sample/animation loaded on pad

### DIFF
--- a/MIDIchlorians/MIDIchlorians/GridCollectionViewCell.swift
+++ b/MIDIchlorians/MIDIchlorians/GridCollectionViewCell.swift
@@ -7,37 +7,60 @@
 //
 
 import UIKit
+import SnapKit
 
 class GridCollectionViewCell: UICollectionViewCell, PadView {
     var rowNumber = 0
     var columnNumber = 0
+    var sampleLabel: UILabel!
+    var animationLabel: UILabel!
+    var imageView: UIImageView!
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        sampleLabel = UILabel(frame: CGRect.zero)
+        sampleLabel.textAlignment = .center
+        contentView.addSubview(sampleLabel)
+
+        animationLabel = UILabel(frame: CGRect.zero)
+        sampleLabel.textAlignment = .center
+        contentView.addSubview(animationLabel)
+
+        imageView = UIImageView(frame: CGRect.zero)
+        contentView.addSubview(imageView)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
 
     func setDefaultAppearance() {
         self.backgroundColor = UIColor.darkGray
     }
-}
-
-extension GridCollectionViewCell: AnimatablePad {
-
-    func animate(image: UIImage) {
-        let imageView = UIImageView(image: image)
-        imageView.frame.size = self.frame.size
-        self.contentView.addSubview(imageView)
-    }
-
-    func animate(backgroundColour: UIColor) {
-        self.backgroundColor = backgroundColour
-    }
-
-    func clearAnimation() {
-        self.contentView.subviews.forEach { $0.removeFromSuperview() }
-        setDefaultAppearance()
-    }
 
     func assign(sample: String) {
+        sampleLabel.snp.makeConstraints { (make) -> Void in
+            make.top.equalTo(contentView)
+            make.bottom.equalTo(contentView)
+            make.left.equalTo(contentView)
+            make.width.equalTo(contentView).dividedBy(2)
+        }
+        sampleLabel.text = "S"
     }
 
     func assign(animation: AnimationSequence) {
+        animationLabel.snp.makeConstraints { (make) -> Void in
+            make.top.equalTo(contentView)
+            make.bottom.equalTo(contentView)
+            make.right.equalTo(contentView)
+            make.width.equalTo(contentView).dividedBy(2)
+        }
+        animationLabel.text = "A"
+    }
+
+    func clearIndicators() {
+        sampleLabel.text = nil
+        animationLabel.text = nil
     }
 
     // This cell is selected in the edit mode
@@ -48,5 +71,22 @@ extension GridCollectionViewCell: AnimatablePad {
 
     func unselect() {
         layer.borderWidth = 0.0
+    }
+}
+
+extension GridCollectionViewCell: AnimatablePad {
+
+    func animate(image: UIImage) {
+        imageView.frame = contentView.frame
+        imageView.image = image
+    }
+
+    func animate(backgroundColour: UIColor) {
+        self.backgroundColor = backgroundColour
+    }
+
+    func clearAnimation() {
+        imageView.image = nil
+        setDefaultAppearance()
     }
 }

--- a/MIDIchlorians/MIDIchlorians/GridCollectionViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/GridCollectionViewController.swift
@@ -11,6 +11,11 @@ import UIKit
 // Provides the data source and layout information for the underying GridCollectionView
 // Events that happen on the collection view will be sent to the parent GridController, not this view controller.
 class GridCollectionViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
+    var mode: Mode = .playing {
+        didSet {
+            collectionView?.reloadData()
+        }
+    }
     // the currently visible 6x8 grid of pads
     var padGrid: [[Pad]] = [] {
         didSet {
@@ -54,26 +59,36 @@ class GridCollectionViewController: UICollectionViewController, UICollectionView
 
             let pad = padGrid[indexPath.section][indexPath.row]
 
-            if let sample = pad.getAudioFile() {
-                cell.assign(sample: sample)
-            }
-
-            if let animation = pad.getAnimation() {
-                cell.assign(animation: animation)
-            }
-
-            if selectedIndexPath == indexPath {
-                cell.setSelected()
-            } else {
-                cell.unselect()
-            }
-
             cell.rowNumber = indexPath.section
             cell.columnNumber = indexPath.item
-            cell.setDefaultAppearance()
 
-            if let colour = colours[pad] {
-                cell.animate(backgroundColour: colour.uiColor)
+            // reset the styles of the cell
+            cell.setDefaultAppearance()
+            cell.clearIndicators()
+
+            // and then assign styles based on the mode
+            switch mode {
+            case .playing:
+                break
+            case .editing:
+                if let sample = pad.getAudioFile() {
+                    cell.assign(sample: sample)
+                }
+
+                if let animation = pad.getAnimation() {
+                    cell.assign(animation: animation)
+                }
+
+                // if selected, highlight
+                if selectedIndexPath == indexPath {
+                    cell.setSelected()
+                } else {
+                    cell.unselect()
+                }
+            case .design:
+                if let colour = colours[pad] {
+                    cell.animate(backgroundColour: colour.uiColor)
+                }
             }
 
             return cell

--- a/MIDIchlorians/MIDIchlorians/GridController.swift
+++ b/MIDIchlorians/MIDIchlorians/GridController.swift
@@ -17,6 +17,7 @@ class GridController: NSObject {
     }
     var mode: Mode = .playing {
         didSet {
+            gridCollectionVC.mode = mode
             // when we enter playing mode, want to set unselect pads
             if mode == .playing {
                 self.selectedIndexPath = nil


### PR DESCRIPTION
It looks primitive for now, once the designs come in this will be changed.

<img width="1020" alt="screen shot 2017-04-02 at 6 00 59 pm" src="https://cloud.githubusercontent.com/assets/1749303/24586266/d27b8a6c-17ce-11e7-97ea-4aee0991cc18.png">


