### PR TITLE
Allowing animations to play at different frequencies in a beat

### DIFF
--- a/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
+++ b/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		334970C71E72B83D009C78DF /* AudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334970C61E72B83D009C78DF /* AudioManager.swift */; };
 		334970C91E72B86B009C78DF /* LowLatencyAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334970C81E72B86B009C78DF /* LowLatencyAudio.swift */; };
 		334CE58C1E8A3ED00095E143 /* AnimationTypeCreationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334CE58B1E8A3ED00095E143 /* AnimationTypeCreationMode.swift */; };
+		338275391E924FA500C6B3B7 /* BeatFrequency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338275381E924FA500C6B3B7 /* BeatFrequency.swift */; };
 		33A2754D1E7BEF56000B1B15 /* Colour.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A2754C1E7BEF56000B1B15 /* Colour.swift */; };
 		33BCC5AA1E85064900D8489F /* AnimatableGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BCC5A91E85064900D8489F /* AnimatableGrid.swift */; };
 		33BCC5AC1E85067A00D8489F /* AnimatablePad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BCC5AB1E85067A00D8489F /* AnimatablePad.swift */; };
@@ -144,6 +145,7 @@
 		334970C61E72B83D009C78DF /* AudioManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AudioManager.swift; path = MIDIchlorians/AudioManager.swift; sourceTree = "<group>"; };
 		334970C81E72B86B009C78DF /* LowLatencyAudio.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LowLatencyAudio.swift; sourceTree = "<group>"; };
 		334CE58B1E8A3ED00095E143 /* AnimationTypeCreationMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationTypeCreationMode.swift; sourceTree = "<group>"; };
+		338275381E924FA500C6B3B7 /* BeatFrequency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeatFrequency.swift; sourceTree = "<group>"; };
 		33A2754C1E7BEF56000B1B15 /* Colour.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Colour.swift; sourceTree = "<group>"; };
 		33BCC5A91E85064900D8489F /* AnimatableGrid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableGrid.swift; sourceTree = "<group>"; };
 		33BCC5AB1E85067A00D8489F /* AnimatablePad.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatablePad.swift; sourceTree = "<group>"; };
@@ -378,6 +380,7 @@
 				33BCC5AB1E85067A00D8489F /* AnimatablePad.swift */,
 				33CC26C61E891E840077F0ED /* AnimationManager.swift */,
 				334CE58B1E8A3ED00095E143 /* AnimationTypeCreationMode.swift */,
+				338275381E924FA500C6B3B7 /* BeatFrequency.swift */,
 			);
 			name = Animation;
 			sourceTree = "<group>";
@@ -866,6 +869,7 @@
 				E9EC7C4B1E83A81900769A8F /* TopBarController.swift in Sources */,
 				E9158EB21E8645F800B7ADF9 /* PadView.swift in Sources */,
 				E9A1A6081E8E4061001B13DB /* SidePaneDelegate.swift in Sources */,
+				338275391E924FA500C6B3B7 /* BeatFrequency.swift in Sources */,
 				E93A02C61E73F5FA00DFB2B7 /* AnimationTableViewCell.swift in Sources */,
 				E9158EAB1E860CDB00B7ADF9 /* GridController.swift in Sources */,
 				334970BF1E72557D009C78DF /* AnimationType.swift in Sources */,

--- a/MIDIchlorians/MIDIchlorians/AnimationEngine.swift
+++ b/MIDIchlorians/MIDIchlorians/AnimationEngine.swift
@@ -1,15 +1,21 @@
 import UIKit
 
 class AnimationEngine: NSObject {
-
     static var updater: CADisplayLink!
+
+    private static var bpm: Int = Config.defaultBPM
     private static var temporaryVariableForAnimationArea: AnimatableGrid?
+
     static var animationArea: AnimatableGrid? {
         get { return temporaryVariableForAnimationArea }
         set { temporaryVariableForAnimationArea = newValue }
     }
     static var animationSequences = [AnimationSequence]()
     static var previousAnimatedIndexPaths = [IndexPath]()
+
+    static func set(beatsPerMinute: Int) {
+        bpm = beatsPerMinute
+    }
 
     static func set(animationGrid: AnimatableGrid) {
         animationArea = animationGrid
@@ -25,7 +31,7 @@ class AnimationEngine: NSObject {
 
     static func start() {
         updater = CADisplayLink(target: self, selector: #selector(animationLoop))
-        updater.preferredFramesPerSecond = Config.animationFrequency
+        updater.preferredFramesPerSecond = (self.bpm * BeatFrequency.max) / Config.numberOfSecondsInMinute
         updater.add(to: RunLoop.current, forMode: RunLoopMode.commonModes)
     }
 
@@ -50,7 +56,7 @@ class AnimationEngine: NSObject {
         previousAnimatedIndexPaths = [IndexPath]()
         for index in 0..<animationSequences.count {
             let animationSequence = animationSequences[index]
-            guard let animationSequenceBits = animationSequence.next() else {
+            guard let animationSequenceBits = animationSequence.nextFrame() else {
                 animationSequence.toBeRemoved = true
                 continue
             }

--- a/MIDIchlorians/MIDIchlorians/AnimationManager.swift
+++ b/MIDIchlorians/MIDIchlorians/AnimationManager.swift
@@ -35,6 +35,7 @@ class AnimationManager {
     }
 
     func getAnimationSequenceForAnimationType(animationTypeName: String,
+                                              beatFrequency: BeatFrequency = BeatFrequency.eight,
                                               indexPath: IndexPath) -> AnimationSequence? {
         var animationSequence = AnimationSequence()
 
@@ -59,6 +60,7 @@ class AnimationManager {
             }
         }
         animationSequence.name = animationTypeName
+        animationSequence.frequencyPerBeat = beatFrequency
         return animationSequence
     }
 

--- a/MIDIchlorians/MIDIchlorians/AnimationSequence.swift
+++ b/MIDIchlorians/MIDIchlorians/AnimationSequence.swift
@@ -13,7 +13,7 @@ class AnimationSequence {
     private var tickCounter: Int
     var toBeRemoved: Bool
     var name: String?
-    private var frequencyPerBeat: BeatFrequency = BeatFrequency.eight
+    var frequencyPerBeat: BeatFrequency = BeatFrequency.eight
     private var frameCount: Int
 
     convenience init(beatFrequency: BeatFrequency) {

--- a/MIDIchlorians/MIDIchlorians/BeatFrequency.swift
+++ b/MIDIchlorians/MIDIchlorians/BeatFrequency.swift
@@ -1,0 +1,41 @@
+//
+//  BeatFrequency.swift
+//  MIDIchlorians
+//
+//  Created by anands on 3/4/17.
+//  Copyright © 2017 nus.cs3217.a0118897. All rights reserved.
+//
+
+import Foundation
+
+enum BeatFrequency: Int {
+    case one = 1
+    case two = 2
+    case four = 4
+    case eight = 8
+    case sixteen = 16
+
+    init(name: String) {
+        guard let number = Int(name) else {
+            self = BeatFrequency.one
+            return
+        }
+        guard let beatFrequency = BeatFrequency(rawValue: number) else {
+            self = BeatFrequency.one
+            return
+        }
+        self = beatFrequency
+    }
+
+    static var max: Int {
+        return BeatFrequency.sixteen.rawValue
+    }
+
+    func framesInABeat() -> Int {
+        return BeatFrequency.max / rawValue
+    }
+
+    func getJSON() -> String {
+        return String(rawValue)
+    }
+}

--- a/MIDIchlorians/MIDIchlorians/Config.swift
+++ b/MIDIchlorians/MIDIchlorians/Config.swift
@@ -14,7 +14,7 @@ struct Config {
     static let numberOfRows = 6
     static let numberOfColumns = 8
     static let numberOfPages = 6
-    static let animationFrequency = 16
+    static let numberOfSecondsInMinute = 60
     static let defaultBPM = 120
     static let sound = [
         [
@@ -109,6 +109,7 @@ struct Config {
 
     static let animationSequenceArrayKey = "animationBitsArray"
     static let animationSequenceNameKey = "name"
+    static let animationSequenceFrequencyKey = "frequencyPerBeat"
 
     static let animationTypeSpreadName = "Spread"
     static let animationTypeSparkName = "Spark"

--- a/MIDIchlorians/MIDIchlorians/ViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/ViewController.swift
@@ -22,6 +22,7 @@ class ViewController: UIViewController {
     internal var sidePaneController: SidePaneController!
     internal var animationDesignController: AnimationDesignerController!
     internal var gridController: GridController!
+    internal var animationEngine: AnimationEngine!
     internal var currentSession: Session! {
         didSet {
             if currentSession != nil {
@@ -141,6 +142,7 @@ class ViewController: UIViewController {
     // Sets up the animation engine
     private func setUpAnimation() {
         AnimationEngine.set(animationGrid: gridController.gridView)
+        AnimationEngine.set(beatsPerMinute: Config.defaultBPM)
         AnimationEngine.start()
     }
 

--- a/MIDIchlorians/MIDIchlorians/ViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/ViewController.swift
@@ -22,7 +22,6 @@ class ViewController: UIViewController {
     internal var sidePaneController: SidePaneController!
     internal var animationDesignController: AnimationDesignerController!
     internal var gridController: GridController!
-    internal var animationEngine: AnimationEngine!
     internal var currentSession: Session! {
         didSet {
             if currentSession != nil {


### PR DESCRIPTION
I have defined an enum called `BeatFrequency`, which determines the number of times an animation tick will occur in a beat:
- `BeatFrequency.one` means each tick of animation (or each frame on the AnimationDesigner timeline) will last an entire beat
- `BeatFrequency.two` means each tick of animation (or each frame on the AnimationDesigner timeline) will be half the duration of a beat
...and so on.

So lower the `beatFrequency` of an `AnimationSequence`, the longer the animation lasts, and the slower the animation.

Let me know if I can improve the naming to make it clearer.

So now the `AnimationEngine` has a frame rate (per second) of `bpm/60`*`16` since the shortest animation frame can last 1/16th of a beat.

Take a look and let me know if I have understood it correctly. The implementation is not complete (still need to expose an API for UI to create an `AnimationSequence` of a given `AnimationType` with a given `beatFrequency`)