### PR TITLE
Remove animation bit from animation sequence

### DIFF
--- a/MIDIchlorians/MIDIchlorians/AnimationSequence.swift
+++ b/MIDIchlorians/MIDIchlorians/AnimationSequence.swift
@@ -43,6 +43,17 @@ class AnimationSequence {
         animationBitsArray[atTick] = array
     }
 
+    func removeAnimationBit(atTick: Int, animationBit: AnimationBit) {
+        guard var animationBits = animationBitsArray[atTick] else {
+            return
+        }
+        guard let indexOfAnimationBit = animationBits.index(of: animationBit) else {
+            return
+        }
+        animationBits.remove(at: indexOfAnimationBit)
+        animationBitsArray[atTick] = animationBits
+    }
+
     func next() -> [AnimationBit]? {
         if tickCounter >= animationBitsArray.count {
             return nil

--- a/MIDIchlorians/MIDIchlorians/GridController.swift
+++ b/MIDIchlorians/MIDIchlorians/GridController.swift
@@ -183,6 +183,16 @@ extension GridController: PadDelegate {
             if let colour = self.colour {
                 // in design mode and we have a colour selected, so change the colour
                 // temp heck to change colour, since Pad doesn't have a colour
+                if let existingColour = grid.colours[selectedFrame][pad] {
+                    self.animationSequence.removeAnimationBit(
+                        atTick: selectedFrame,
+                        animationBit: AnimationBit(
+                            colour: existingColour,
+                            row: indexPath.section,
+                            column: indexPath.item
+                        )
+                    )
+                }
                 grid.colours[selectedFrame][pad] = colour
                 self.animationSequence.addAnimationBit(
                     atTick: selectedFrame,
@@ -192,9 +202,19 @@ extension GridController: PadDelegate {
                         column: indexPath.item
                     )
                 )
-
                 grid.collectionView?.reloadItems(at: [indexPath])
             } else {
+                guard let colourToBeRemoved = grid.colours[selectedFrame][pad] else {
+                    return
+                }
+                self.animationSequence.removeAnimationBit(
+                    atTick: selectedFrame,
+                    animationBit: AnimationBit(
+                        colour: colourToBeRemoved,
+                        row: indexPath.section,
+                        column: indexPath.item
+                    )
+                )
                 grid.colours[selectedFrame][pad] = nil
                 grid.collectionView?.reloadItems(at: [indexPath])
             }


### PR DESCRIPTION
I have created a function to remove an animation bit from an animation sequence at a given tick.

I realised that we can add multiple animation bits for the same index path but different colours at the same tick, so we need to remove the old animation bit for a pad at a given tick (if any) each time we add a new one.

This PR handles issue #76 