### PR TITLE
Session table edit/remove using swipe

### DIFF
--- a/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
+++ b/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		E9AD301B1E88EBB300801A9F /* PadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AD301A1E88EBB300801A9F /* PadDelegate.swift */; };
 		E9AD301D1E8BA9FE00801A9F /* AnimationDesignerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AD301C1E8BA9FE00801A9F /* AnimationDesignerController.swift */; };
 		E9C54EB91E9773B300141BCE /* SyncViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C54EB81E9773B300141BCE /* SyncViewController.swift */; };
+		E9C54EBD1E98CA9B00141BCE /* AlertActionTextFieldSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C54EBC1E98CA9B00141BCE /* AlertActionTextFieldSync.swift */; };
 		E9C6712E1E94B61900777846 /* SelectedPadTrackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C6712D1E94B61900777846 /* SelectedPadTrackingView.swift */; };
 		E9C671301E94B7B100777846 /* RemoveButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C6712F1E94B7B100777846 /* RemoveButton.swift */; };
 		E9E780741E955B8F00F5CC65 /* PageDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E780731E955B8F00F5CC65 /* PageDelegate.swift */; };
@@ -241,6 +242,7 @@
 		E9AD301A1E88EBB300801A9F /* PadDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PadDelegate.swift; sourceTree = "<group>"; };
 		E9AD301C1E8BA9FE00801A9F /* AnimationDesignerController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationDesignerController.swift; sourceTree = "<group>"; };
 		E9C54EB81E9773B300141BCE /* SyncViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncViewController.swift; sourceTree = "<group>"; };
+		E9C54EBC1E98CA9B00141BCE /* AlertActionTextFieldSync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertActionTextFieldSync.swift; sourceTree = "<group>"; };
 		E9C6712D1E94B61900777846 /* SelectedPadTrackingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectedPadTrackingView.swift; sourceTree = "<group>"; };
 		E9C6712F1E94B7B100777846 /* RemoveButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoveButton.swift; sourceTree = "<group>"; };
 		E9E780731E955B8F00F5CC65 /* PageDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageDelegate.swift; sourceTree = "<group>"; };
@@ -349,6 +351,7 @@
 				E9E780791E96284100F5CC65 /* SampleSettingViewController.swift */,
 				E9E7807B1E96361B00F5CC65 /* UIStackView+Extensions.swift */,
 				F31E2B121E8FF1B000C23325 /* CloudManager.swift */,
+				E9C54EBC1E98CA9B00141BCE /* AlertActionTextFieldSync.swift */,
 			);
 			path = MIDIchlorians;
 			sourceTree = "<group>";
@@ -977,6 +980,7 @@
 				334970C91E72B86B009C78DF /* LowLatencyAudio.swift in Sources */,
 				33120E1E1E6FD30A007E7717 /* AppDelegate.swift in Sources */,
 				80299E831E88FAB000CEB465 /* AudioPlayerSetting.swift in Sources */,
+				E9C54EBD1E98CA9B00141BCE /* AlertActionTextFieldSync.swift in Sources */,
 				E9158EB01E86353600B7ADF9 /* GridCollectionViewController.swift in Sources */,
 				E92D6F291E94F5C300E815F1 /* TimelineCollectionViewController.swift in Sources */,
 				E93A02C21E73C27200DFB2B7 /* SidePaneTabBarController.swift in Sources */,

--- a/MIDIchlorians/MIDIchlorians/AlertActionTextFieldSync.swift
+++ b/MIDIchlorians/MIDIchlorians/AlertActionTextFieldSync.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UIKit
 
-
 // Synchronizes the enabled state of an alert action with a text field's contents
 class AlertActionTextFieldSync: NSObject, UITextFieldDelegate {
     private var alertAction: UIAlertAction

--- a/MIDIchlorians/MIDIchlorians/AlertActionTextFieldSync.swift
+++ b/MIDIchlorians/MIDIchlorians/AlertActionTextFieldSync.swift
@@ -1,0 +1,43 @@
+//
+//  AlertActionTextFieldSync.swift
+//  MIDIchlorians
+//
+//  Created by Zhi An Ng on 8/4/17.
+//  Copyright © 2017 nus.cs3217.a0118897. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+
+// Synchronizes the enabled state of an alert action with a text field's contents
+class AlertActionTextFieldSync: NSObject, UITextFieldDelegate {
+    private var alertAction: UIAlertAction
+    init(alertAction: UIAlertAction) {
+        self.alertAction = alertAction
+        super.init()
+    }
+
+    // Don't allow return if the field is empty, user must explicitly cancel
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        return !(textField.text?.isEmpty ?? true)
+    }
+
+    // Deactivate the Save button if text field is empty
+    func textField(_ textField: UITextField,
+                   shouldChangeCharactersIn range: NSRange,
+                   replacementString string: String) -> Bool {
+        guard let text = textField.text else {
+            return true
+        }
+
+        let str = (text as NSString).replacingCharacters(in: range, with: string)
+        if str.trimmingCharacters(in: CharacterSet.whitespaces).isEmpty {
+            alertAction.isEnabled = false
+        } else {
+            alertAction.isEnabled = true
+        }
+        return true
+    }
+
+}

--- a/MIDIchlorians/MIDIchlorians/Config.swift
+++ b/MIDIchlorians/MIDIchlorians/Config.swift
@@ -187,14 +187,20 @@ struct Config {
     static let SampleTableTitle = "Samples"
     static let SampleTableReuseIdentifier = "sampleCell"
     static let AnimationTableReuseIdentifier = "animationCell"
+
+    // Session
+    static let SessionEditActionTitle = "Edit"
+    static let SessionRemoveActionTitle = "Remove"
+    static let SessionEditAlertTitle = "Enter a new name"
+    static let SessionEditOkayTitle = "Okay"
+    static let SessionEditCancelTitle = "Cancel"
+    static let SessionRemoveTitleFormat = "Remove %@?"
+    static let SessionRemoveConfirmTitle = "Confirm"
+    static let SessionRemoveCancelTitle = "Cancel"
     static let SessionTableReuseIdentifier = "sessionCell"
 
     static let SampleTableCellHeight: CGFloat = 60
     static let AnimationTableCellHeight: CGFloat = Config.SampleTableCellHeight
-
-    static let SessionEditAlertTitle = "Enter a new name"
-    static let SessionEditOkayTitle = "Save"
-    static let SessionEditCancelTitle = "Cancel"
 
     static let animationBitColourKey = "colour"
     static let animationBitRowKey = "row"

--- a/MIDIchlorians/MIDIchlorians/SessionTableViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/SessionTableViewController.swift
@@ -44,7 +44,7 @@ class SessionTableViewController: UITableViewController {
 
         // have to set target/action here for this to work, not above in the inistnatiation.
         self.newSessionButton.target = self
-        self.newSessionButton.action = #selector(newSession(barButton:))
+        self.newSessionButton.action = #selector(newSession)
 
         self.tableView.register(SessionTableViewCell.self, forCellReuseIdentifier: reuseIdentifier)
         self.tableView.separatorColor = Config.TableViewSeparatorColor
@@ -167,7 +167,7 @@ class SessionTableViewController: UITableViewController {
         delegate?.sessionTable(tableView, didRemove: deletedSession)
     }
 
-    func newSession(barButton: UIBarButtonItem) {
+    func newSession() {
         delegate?.sessionTable(tableView)
     }
 }

--- a/MIDIchlorians/MIDIchlorians/TopBarController.swift
+++ b/MIDIchlorians/MIDIchlorians/TopBarController.swift
@@ -45,7 +45,6 @@ class TopBarController: UIViewController {
         view.addSubview(logo)
 
         sessionButton.setTitle(Config.TopNavSessionLabel, for: .normal)
-        sessionButton.tintColor = UIColor.black
         sessionButton.addTarget(self, action: #selector(sessionSelect(sender:)), for: .touchDown)
 
         saveButton.setTitle(Config.TopNavSaveLabel, for: .normal)


### PR DESCRIPTION
Fixes #108 
Previously used long press to edit, change it to swipe to edit/delete, just like animation table.
You can see a ton of copy paste (the whole alert system is the same as animation, 1 for edit 1 for delete), it's easier this way, but if we see a need (or have time), we can refactor.