### PR TITLE
Dropbox changes

### DIFF
--- a/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
+++ b/MIDIchlorians/MIDIchlorians.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		F3173ABD1E83B2B50095F76A /* AnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3173ABC1E83B2B50095F76A /* AnimationTests.swift */; };
 		F3173ABF1E83B2D50095F76A /* AudioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3173ABE1E83B2D50095F76A /* AudioTests.swift */; };
 		F3173AC11E83B2EF0095F76A /* DataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3173AC01E83B2EF0095F76A /* DataManagerTests.swift */; };
+		F31DB0AC1E9B093C005DB81A /* SyncDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31DB0AB1E9B093C005DB81A /* SyncDelegate.swift */; };
 		F31E2B131E8FF1B000C23325 /* CloudManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31E2B121E8FF1B000C23325 /* CloudManager.swift */; };
 		F32A4CE51E8595F700FF8F1F /* SessionName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32A4CE41E8595F700FF8F1F /* SessionName.swift */; };
 		F34B2A521E7A84AC00FD2C61 /* Pad.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34B2A511E7A84AC00FD2C61 /* Pad.swift */; };
@@ -396,6 +397,7 @@
 		F3173ABC1E83B2B50095F76A /* AnimationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationTests.swift; sourceTree = "<group>"; };
 		F3173ABE1E83B2D50095F76A /* AudioTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioTests.swift; sourceTree = "<group>"; };
 		F3173AC01E83B2EF0095F76A /* DataManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataManagerTests.swift; sourceTree = "<group>"; };
+		F31DB0AB1E9B093C005DB81A /* SyncDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncDelegate.swift; sourceTree = "<group>"; };
 		F31E2B121E8FF1B000C23325 /* CloudManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudManager.swift; sourceTree = "<group>"; };
 		F32A4CE41E8595F700FF8F1F /* SessionName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionName.swift; sourceTree = "<group>"; };
 		F34B2A511E7A84AC00FD2C61 /* Pad.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pad.swift; sourceTree = "<group>"; };
@@ -772,6 +774,7 @@
 				E9EC7C4C1E83B7F100769A8F /* SessionSelectorDelegate.swift */,
 				E92F6C311E751EAE00F5A092 /* Mode.swift */,
 				E93A02B51E7390DD00DFB2B7 /* ModeDelegate.swift */,
+				F31DB0AB1E9B093C005DB81A /* SyncDelegate.swift */,
 			);
 			name = "Top Nav";
 			sourceTree = "<group>";
@@ -1253,6 +1256,7 @@
 				E9C671301E94B7B100777846 /* RemoveButton.swift in Sources */,
 				80A050C21E99302900091411 /* RecordPlaybackDelegate.swift in Sources */,
 				334970C71E72B83D009C78DF /* AudioManager.swift in Sources */,
+				F31DB0AC1E9B093C005DB81A /* SyncDelegate.swift in Sources */,
 				33CC26C71E891E840077F0ED /* AnimationManager.swift in Sources */,
 				E9E780741E955B8F00F5CC65 /* PageDelegate.swift in Sources */,
 				F34B2A521E7A84AC00FD2C61 /* Pad.swift in Sources */,

--- a/MIDIchlorians/MIDIchlorians/AppDelegate.swift
+++ b/MIDIchlorians/MIDIchlorians/AppDelegate.swift
@@ -69,7 +69,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         do {
             let directoryContents = try FileManager.default.contentsOfDirectory(at: docsURL, includingPropertiesForKeys: nil, options: [])
             let audioFiles = directoryContents.filter{ $0.pathExtension == Config.SoundExt }
-                                              .map { $0.deletingPathExtension().lastPathComponent }
+                                              .map { $0.lastPathComponent }
             return audioFiles
 
         } catch {

--- a/MIDIchlorians/MIDIchlorians/AppDelegate.swift
+++ b/MIDIchlorians/MIDIchlorians/AppDelegate.swift
@@ -31,7 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func savePreloadedSamplesToGroup() {
         for (groupName, samplesArray) in preloadedSampleSongs {
             samplesArray.forEach { sample in
-                let success = DataManager.instance.addSampleToGroup(group: groupName, sample: sample)
+                _ = DataManager.instance.addSampleToGroup(group: groupName, sample: sample)
             }
         }
     }

--- a/MIDIchlorians/MIDIchlorians/CloudManager.swift
+++ b/MIDIchlorians/MIDIchlorians/CloudManager.swift
@@ -181,7 +181,7 @@ class CloudManager {
         }
 
         func getMetaDataCallback(filePath: String, sample: String) {
-            let url = docsURL.appendingPathComponent("\(sample).\(Config.SoundExt)")
+            let url = docsURL.appendingPathComponent("\(sample)")
             self.client?.files.upload(path: filePath, input: url).response { response, error in
                 guard let result = response, error == nil else {
                     if !notificationPosted {
@@ -197,7 +197,7 @@ class CloudManager {
 
         //Upload each sample
         for sample in samples {
-            let fileNameExtension = "\(sample).\(Config.SoundExt)"
+            let fileNameExtension = "\(sample)"
             let filePath = "/\(Config.AudioFolderName)/\(fileNameExtension)"
             client?.files.getMetadata(path: filePath).response { response, error in
                 guard response == nil, error != nil else {

--- a/MIDIchlorians/MIDIchlorians/CloudManager.swift
+++ b/MIDIchlorians/MIDIchlorians/CloudManager.swift
@@ -24,18 +24,19 @@ class CloudManager {
         //Just to ensure initialiser is private
     }
 
-    private func postToNotificationCenter( _ result: Bool) {
-        NotificationCenter.default.post(name: Notification.Name(rawValue: Config.cloudManagerNotificationKey),
+    private func postToNotificationCenter(_ key: String, _ result: Bool) {
+        NotificationCenter.default.post(name: Notification.Name(rawValue: key),
                                         object: self, userInfo: ["success": result])
     }
 
-    private func handleResult(result: Bool) {
+    private func handleResult(_ key: String, _ result: Bool) {
         if !result {
             self.isSuccessful = false
         }
         resultsReceived += 1
+        postToNotificationCenter(key, result)
         if resultsReceived  == resultCount {
-            postToNotificationCenter(isSuccessful)
+            postToNotificationCenter(Config.cloudNotificationKey, isSuccessful)
             resultsReceived = 0
             isSuccessful = true
         }
@@ -68,7 +69,7 @@ class CloudManager {
                 //What if the saving fails?
                 _ = dataManager.saveAudio(sample)
             }
-            handleResult(result: true)
+            self.handleResult(Config.audioNotificationKey, true)
         }
 
         func listFolderCallback(result: Files.ListFolderResultSerializer.ValueType) {
@@ -87,7 +88,7 @@ class CloudManager {
                                             destination: destination).response { response, error in
                     guard let result = response, error == nil else {
                         if !notificationPosted {
-                            self.handleResult(result: false)
+                            self.handleResult(Config.audioNotificationKey, false)
                             notificationPosted = true
                         }
                         return
@@ -100,7 +101,7 @@ class CloudManager {
 
         client?.files.listFolder(path: "/\(Config.AudioFolderName)/").response { response, error in
             guard let result = response, error == nil else {
-                self.handleResult(result: false)
+                self.handleResult(Config.audioNotificationKey, false)
                 return
             }
             listFolderCallback(result: result)
@@ -114,7 +115,7 @@ class CloudManager {
             let json = result.1
             guard let dictionary = (try? JSONSerialization.jsonObject(with: json, options: []))
                                          as? [String: Any] else {
-                handleResult(result: false)
+                self.handleResult(Config.animationNotificationKey, false)
                 return
             }
             for (_, jsonString) in dictionary {
@@ -125,12 +126,12 @@ class CloudManager {
                 //What if saving fails
                 _ = dataManager.saveAnimation(animationJSON)
             }
-            handleResult(result: true)
+            self.handleResult(Config.animationNotificationKey, true)
         }
 
         client?.files.download(path: filePath).response { response, error in
             guard let result = response, error == nil else {
-                self.handleResult(result: false)
+                self.handleResult(Config.animationNotificationKey, false)
                 return
             }
             downloadCallBack(result)
@@ -144,7 +145,7 @@ class CloudManager {
             let json = result.1
             guard let dictionary = (try? JSONSerialization.jsonObject(with: json, options: []))
                                          as? [String: Any] else {
-                handleResult(result: false)
+                self.handleResult(Config.sessionNotificationKey, false)
                 return
             }
             for (sessionName, object) in dictionary {
@@ -157,12 +158,12 @@ class CloudManager {
                 _ = self.dataManager.saveSession(sessionName, session)
 
             }
-            handleResult(result: true)
+            self.handleResult(Config.sessionNotificationKey, true)
         }
 
         client?.files.download(path: filePath).response { response, error in
             guard let result = response, error == nil else {
-                self.handleResult(result: false)
+                self.handleResult(Config.sessionNotificationKey, false)
                 return
             }
             downloadCallBack(result)
@@ -181,7 +182,7 @@ class CloudManager {
     private func saveAudios() {
         guard let docsURL = FileManager.default.urls(for: .documentDirectory,
                                                      in: .userDomainMask).last else {
-            handleResult(result: false)
+            self.handleResult(Config.audioNotificationKey, false)
             return
         }
         //Get a list of samples
@@ -193,7 +194,7 @@ class CloudManager {
             guard samples.count == numSamplesUploaded else {
                 return
             }
-            handleResult(result: true)
+            self.handleResult(Config.audioNotificationKey, true)
         }
 
         func getMetaDataCallback(filePath: String, sample: String) {
@@ -201,7 +202,7 @@ class CloudManager {
             self.client?.files.upload(path: filePath, input: url).response { response, error in
                 guard let result = response, error == nil else {
                     if !notificationPosted {
-                        self.handleResult(result: false)
+                        self.handleResult(Config.audioNotificationKey, false)
                         notificationPosted = true
                     }
                     return
@@ -244,10 +245,10 @@ class CloudManager {
         client?.files.upload(path: filePath, mode: Files.WriteMode.overwrite, autorename: false, mute: false,
                              input: jsonData).response { response, error in
             guard response != nil, error == nil else {
-                self.handleResult(result: false)
+                self.handleResult(Config.animationNotificationKey, false)
                 return
             }
-            self.handleResult(result: true)
+            self.handleResult(Config.animationNotificationKey, true)
         }
 
     }
@@ -269,10 +270,10 @@ class CloudManager {
         client?.files.upload(path: filePath, mode: Files.WriteMode.overwrite, autorename: false, mute: false,
                              input: jsonData).response { response, error in
             guard response != nil, error == nil else {
-                self.handleResult(result: false)
+                self.handleResult(Config.sessionNotificationKey, false)
                 return
             }
-            self.handleResult(result: true)
+            self.handleResult(Config.sessionNotificationKey, true)
         }
 
     }

--- a/MIDIchlorians/MIDIchlorians/Config.swift
+++ b/MIDIchlorians/MIDIchlorians/Config.swift
@@ -309,7 +309,5 @@ struct Config {
     static let animationTypeSparkName = "Spark"
     static let animationTypeRainbowName = "Rainbow"
 
-    static let animationNotificationKey = "animation"
-    static let sessionNotificationKey = "session"
-    static let audioNotificationKey = "audio"
+    static let cloudManagerNotificationKey = "Cloud"
 }

--- a/MIDIchlorians/MIDIchlorians/Config.swift
+++ b/MIDIchlorians/MIDIchlorians/Config.swift
@@ -312,5 +312,8 @@ struct Config {
     static let animationTypeSparkName = "Spark"
     static let animationTypeRainbowName = "Rainbow"
 
-    static let cloudManagerNotificationKey = "Cloud"
+    static let audioNotificationKey = "Audio"
+    static let animationNotificationKey = "Animation"
+    static let sessionNotificationKey = "Session"
+    static let cloudNotificationKey = "Cloud"
 }

--- a/MIDIchlorians/MIDIchlorians/SyncDelegate.swift
+++ b/MIDIchlorians/MIDIchlorians/SyncDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  SyncDelegate.swift
+//  MIDIchlorians
+//
+//  Created by Advay Pal on 10/04/17.
+//  Copyright © 2017 nus.cs3217.a0118897. All rights reserved.
+//
+
+// Adopt this protocol to react when dropbox web view needs to be loaded
+protocol SyncDelegate: class {
+    func loadDropboxWebView()
+}

--- a/MIDIchlorians/MIDIchlorians/SyncViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/SyncViewController.swift
@@ -14,6 +14,7 @@ class SyncViewController: UIViewController {
     private var upload: UIButton!
     private var download: UIButton!
     private var stackView: UIStackView!
+    weak var delegate: SyncDelegate?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -46,11 +47,7 @@ class SyncViewController: UIViewController {
 
     func onUpload() {
         if DropboxClientsManager.authorizedClient == nil {
-            DropboxClientsManager.authorizeFromController(UIApplication.shared,
-                                                          controller: self,
-                                                          openURL: { (url: URL) -> Void in
-                                                            UIApplication.shared.open(url) },
-                                                          browserAuth: false)
+            delegate?.loadDropboxWebView()
         } else {
             CloudManager.instance.saveToDropbox()
         }
@@ -59,11 +56,7 @@ class SyncViewController: UIViewController {
 
     func onDownload() {
         if DropboxClientsManager.authorizedClient == nil {
-            DropboxClientsManager.authorizeFromController(UIApplication.shared,
-                                                          controller: self,
-                                                          openURL: { (url: URL) -> Void in
-                                                            UIApplication.shared.open(url) },
-                                                          browserAuth: false)
+            delegate?.loadDropboxWebView()
         } else {
             CloudManager.instance.loadFromDropbox()
         }

--- a/MIDIchlorians/MIDIchlorians/TopBarController.swift
+++ b/MIDIchlorians/MIDIchlorians/TopBarController.swift
@@ -34,6 +34,11 @@ class TopBarController: UIViewController {
 
     weak var modeSwitchDelegate: ModeSwitchDelegate?
     weak var sessionSelectorDelegate: SessionSelectorDelegate?
+    var syncDelegate: SyncDelegate? {
+        didSet {
+            self.syncViewController.delegate = syncDelegate
+        }
+    }
 
     init() {
         super.init(nibName: nil, bundle: nil)

--- a/MIDIchlorians/MIDIchlorians/ViewController.swift
+++ b/MIDIchlorians/MIDIchlorians/ViewController.swift
@@ -82,6 +82,7 @@ class ViewController: UIViewController {
 
         topBarController.modeSwitchDelegate = self
         topBarController.sessionSelectorDelegate = self
+        topBarController.syncDelegate = self
         topBarController.setTargetActionOfSaveButton(target: self, selector: #selector(saveCurrentSession))
     }
 
@@ -339,4 +340,15 @@ extension ViewController: PadDelegate {
         animationDesignController.pad(animationUpdated: animation)
     }
 
+}
+
+extension ViewController: SyncDelegate {
+    // Loads the dropbox authentication
+    func loadDropboxWebView() {
+        DropboxClientsManager.authorizeFromController(UIApplication.shared,
+                                                      controller: self,
+                                                      openURL: { (url: URL) -> Void in
+                                                        UIApplication.shared.open(url) },
+                                                      browserAuth: true)
+    }
 }


### PR DESCRIPTION
Following changes are made:

1. Send one extra notification on completion of the upload/download. This notification uses the same format as the last 3, with the key cloudNotificationKey
2. Change saving of sample names in db to include extension. Did this because I feel we may support more types in the future
3. Moved Dropbox authentication code to main VC

@ngzhian I notice that when I do a sync download, the various tables on the UI update. However, this update is only visible if I pull it down to refresh, or if I move to another VC, and then back to that list. If I remain on the list from before pressing download, the list doesn't automatically refresh. Is there a way to take care of this?

@ngzhian @anand-sundaram @Tzyinc You guys will need to do a fresh install of the app once this is merged